### PR TITLE
fix(#2): align beckn namespace URI to https://schema.beckn.io/

### DIFF
--- a/schema/context.jsonld
+++ b/schema/context.jsonld
@@ -5,7 +5,7 @@
     "xsd": "http://www.w3.org/2001/XMLSchema#",
     "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
     "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
-    "beckn": "https://schema.beckn.io/core/v2.0/",
+    "beckn": "https://schema.beckn.io/",
     "AcceptedPaymentMethod": "beckn:AcceptedPaymentMethod",
     "AckResponse": "beckn:AckResponse",
     "Address": "beckn:Address",

--- a/schema/vocab.jsonld
+++ b/schema/vocab.jsonld
@@ -1,7 +1,7 @@
 {
   "@context": {
     "@version": 1.1,
-    "beckn": "https://schema.beckn.io/core/v2.0/",
+    "beckn": "https://schema.beckn.io/",
     "owl": "http://www.w3.org/2002/07/owl#",
     "schema": "https://schema.org/",
     "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",


### PR DESCRIPTION
Fixes #2

## Problem

`context.jsonld` and `vocab.jsonld` both declared:

```json
"beckn": "https://schema.beckn.io/core/v2.0/"
```

Every `attributes.yaml` file declares `'@context': const: "https://schema.beckn.io/"` and uses `@type` values like `beckn:Catalog`, `beckn:Item`, etc.

When a JSON-LD processor loads `https://schema.beckn.io/` as the context document and that document says `"beckn": "https://schema.beckn.io/core/v2.0/"`, then `beckn:Catalog` expands to `https://schema.beckn.io/core/v2.0/Catalog`. That is wrong. The intended concept IRI is `https://schema.beckn.io/Catalog` — no `/core/v2.0/` subpath, per the single-namespace architectural decision.

## Fix

Changed the `beckn` prefix declaration in both JSON-LD files:

```diff
- "beckn": "https://schema.beckn.io/core/v2.0/"
+ "beckn": "https://schema.beckn.io/"
```

## Files changed

- `schema/context.jsonld` — one-line change to the `beckn` prefix
- `schema/vocab.jsonld` — same one-line change

No changes to any `attributes.yaml` files. The `@context: const: "https://schema.beckn.io/"` and `@type: beckn:*` values in those files were already correct.
