### PR TITLE
fix(#4): replace bare type:object with allOf $ref; fix Fulfillment.state allOf syntax

### DIFF
--- a/schema/Catalog/v2.0/attributes.yaml
+++ b/schema/Catalog/v2.0/attributes.yaml
@@ -24,7 +24,8 @@ properties:
     example: "https://bpp.example.com"
   descriptor:
     description: A verbal summary of the catalog for humans, AI agents, etc to read and understand the context.
-    type: object
+    allOf:
+    - $ref: "https://schema.beckn.io/Descriptor/v2.0"
   id:
     description: Unique identifier for the catalog
     type: string
@@ -47,7 +48,9 @@ properties:
     type: string
     example: tech-store-001
   validity:
-    type: object
+    description: The time period during which this catalog is valid
+    allOf:
+    - $ref: "https://schema.beckn.io/TimePeriod/v2.0"
 required:
 - '@context'
 - '@type'

--- a/schema/Fulfillment/v2.0/attributes.yaml
+++ b/schema/Fulfillment/v2.0/attributes.yaml
@@ -48,7 +48,7 @@ properties:
   state:
     description: The current state of fulfillment
     allOf:
-      $ref: "https://schema.beckn.io/State/v2.0"
+    - $ref: "https://schema.beckn.io/State/v2.0"
   stages:
     description: The various stages of the fulfillment
     type: array


### PR DESCRIPTION
Fixes #4

## Changes

### `schema/Catalog/v2.0/attributes.yaml`

**`descriptor`** — was `type: object` with no schema reference. Fixed to use `allOf: $ref` pointing to `Descriptor/v2.0`, with description preserved:
```diff
- descriptor:
-   description: A verbal summary of the catalog...
-   type: object
+ descriptor:
+   description: A verbal summary of the catalog...
+   allOf:
+   - $ref: "https://schema.beckn.io/Descriptor/v2.0"
```

**`validity`** — was bare `type: object` with no description and no schema reference. Fixed:
```diff
- validity:
-   type: object
+ validity:
+   description: The time period during which this catalog is valid
+   allOf:
+   - $ref: "https://schema.beckn.io/TimePeriod/v2.0"
```

### `schema/Fulfillment/v2.0/attributes.yaml`

**`state`** — had `allOf` pointing to a mapping instead of a sequence (missing `-` list item marker), making it invalid JSON Schema. Fixed:
```diff
  state:
    description: The current state of fulfillment
    allOf:
-     $ref: "https://schema.beckn.io/State/v2.0"
+   - $ref: "https://schema.beckn.io/State/v2.0"
```

## Style decision

All nested object references now consistently use `allOf: - $ref:` rather than bare `$ref`, allowing description and other sibling keywords at the point of use. This is valid in JSON Schema Draft 2020-12 and consistent with how `agent`, `mode`, and `fulfillmentAttributes` are defined in `Fulfillment`.
