### PR TITLE
fix(#6): add additionalProperties: false to 25 object schemas

### DIFF
--- a/schema/CallbackAction/v2.0/attributes.yaml
+++ b/schema/CallbackAction/v2.0/attributes.yaml
@@ -15,4 +15,4 @@ properties:
     - https://schema.beckn.io/OnCancelAction
     - https://schema.beckn.io/OnRateAction
     - https://schema.beckn.io/OnSupportAction
-    - https://schema.beckn.io/OnAsyncError
+    - https://schema.beckn.io/OnAsyncErroradditionalProperties: false

--- a/schema/CancellationOutcome/v2.0/attributes.yaml
+++ b/schema/CancellationOutcome/v2.0/attributes.yaml
@@ -10,3 +10,4 @@ properties:
     properties:
       '@type':
         default: beckn:CancellationOutcome
+additionalProperties: false

--- a/schema/CancellationPolicy/v2.0/attributes.yaml
+++ b/schema/CancellationPolicy/v2.0/attributes.yaml
@@ -14,3 +14,4 @@ properties:
     const: beckn:CancellationPolicy
     x-jsonld:
       '@id': schema:CreativeWork
+additionalProperties: false

--- a/schema/CancellationReason/v2.0/attributes.yaml
+++ b/schema/CancellationReason/v2.0/attributes.yaml
@@ -10,3 +10,4 @@ properties:
     properties:
       '@type':
         default: beckn:CancellationReason
+additionalProperties: false

--- a/schema/CatalogProcessingResult/v2.0/attributes.yaml
+++ b/schema/CatalogProcessingResult/v2.0/attributes.yaml
@@ -28,3 +28,4 @@ properties:
 required:
 - catalogId
 - status
+additionalProperties: false

--- a/schema/CategoryCode/v2.0/attributes.yaml
+++ b/schema/CategoryCode/v2.0/attributes.yaml
@@ -28,3 +28,4 @@ properties:
 required:
 - '@type'
 - schema:codeValue
+additionalProperties: false

--- a/schema/Context/v2.0/attributes.yaml
+++ b/schema/Context/v2.0/attributes.yaml
@@ -70,3 +70,4 @@ properties:
     description: Version of beckn protocol being used by the sender
     type: string
     const: 2.1.0
+additionalProperties: false

--- a/schema/ContractItem/v2.0/attributes.yaml
+++ b/schema/ContractItem/v2.0/attributes.yaml
@@ -35,3 +35,4 @@ properties:
     - $ref: "https://schema.beckn.io/Quantity/v2.0"
 required:
 - itemId
+additionalProperties: false

--- a/schema/Descriptor/v2.0/attributes.yaml
+++ b/schema/Descriptor/v2.0/attributes.yaml
@@ -41,3 +41,4 @@ properties:
       $ref: "https://schema.beckn.io/MediaFile/v2.0"
 required:
 - '@type'
+additionalProperties: false

--- a/schema/DisplayedRating/v2.0/attributes.yaml
+++ b/schema/DisplayedRating/v2.0/attributes.yaml
@@ -23,3 +23,4 @@ properties:
     example: 4.8
 required:
 - '@type'
+additionalProperties: false

--- a/schema/Document/v2.0/attributes.yaml
+++ b/schema/Document/v2.0/attributes.yaml
@@ -40,3 +40,4 @@ properties:
   - label
   - url
   - mimeType
+additionalProperties: false

--- a/schema/Eligibility/v2.0/attributes.yaml
+++ b/schema/Eligibility/v2.0/attributes.yaml
@@ -15,3 +15,4 @@ properties:
     type: string
 x-jsonld:
   '@id': schema:DefinedRegion|schema:QuantitativeValue
+additionalProperties: false

--- a/schema/Error/v2.0/attributes.yaml
+++ b/schema/Error/v2.0/attributes.yaml
@@ -18,3 +18,4 @@ properties:
 required:
 - code
 - message
+additionalProperties: false

--- a/schema/ErrorResponse/v2.0/attributes.yaml
+++ b/schema/ErrorResponse/v2.0/attributes.yaml
@@ -8,3 +8,4 @@ properties:
     $ref: "https://schema.beckn.io/Error/v2.0"
 required:
 - error
+additionalProperties: false

--- a/schema/Feedback/v2.0/attributes.yaml
+++ b/schema/Feedback/v2.0/attributes.yaml
@@ -3,3 +3,4 @@ $schema: "https://json-schema.org/draft/2020-12/schema"
 description: Feedback collected from a user (consumer, provider, or fulfillment agent)
 title: Feedback
 type: object
+additionalProperties: false

--- a/schema/Intent/v2.0/attributes.yaml
+++ b/schema/Intent/v2.0/attributes.yaml
@@ -42,3 +42,4 @@ anyOf:
 - required:
   - filters
   - spatial
+additionalProperties: false

--- a/schema/MediaFile/v2.0/attributes.yaml
+++ b/schema/MediaFile/v2.0/attributes.yaml
@@ -12,3 +12,4 @@ properties:
     description: URL to the document
     type: string
     format: uri
+additionalProperties: false

--- a/schema/PaymentTerms/v2.0/attributes.yaml
+++ b/schema/PaymentTerms/v2.0/attributes.yaml
@@ -33,3 +33,4 @@ properties:
     description: 'Rail-specific attribute pack (e.g., UPI: VPA/UTR; CARD: token/3DS; BNPL: plan/schedule)'
     allOf:
     - $ref: "https://schema.beckn.io/Attributes/v2.0"
+additionalProperties: false

--- a/schema/RatingForm/v2.0/attributes.yaml
+++ b/schema/RatingForm/v2.0/attributes.yaml
@@ -70,3 +70,4 @@ properties:
   - '@type'
   - target
   - feedbackRequired
+additionalProperties: false

--- a/schema/RatingInput/v2.0/attributes.yaml
+++ b/schema/RatingInput/v2.0/attributes.yaml
@@ -72,3 +72,4 @@ required:
 - '@type'
 - target
 - range
+additionalProperties: false

--- a/schema/RefundTerms/v2.0/attributes.yaml
+++ b/schema/RefundTerms/v2.0/attributes.yaml
@@ -9,3 +9,4 @@ properties:
     enum:
     - SOURCE_ACCOUNT
     - OTHER
+additionalProperties: false

--- a/schema/RequestAction/v2.0/attributes.yaml
+++ b/schema/RequestAction/v2.0/attributes.yaml
@@ -15,4 +15,4 @@ properties:
     - https://schema.beckn.io/CancelAction/v2.0
     - https://schema.beckn.io/RateAction/v2.0
     - https://schema.beckn.io/SupportAction/v2.0
-  
+  additionalProperties: false

--- a/schema/SupportTicket/v2.0/attributes.yaml
+++ b/schema/SupportTicket/v2.0/attributes.yaml
@@ -9,3 +9,4 @@ properties:
     type: string
   supportTicketAttributes:
     $ref: "https://schema.beckn.io/Attributes/v2.0"
+additionalProperties: false

--- a/schema/TimePeriod/v2.0/attributes.yaml
+++ b/schema/TimePeriod/v2.0/attributes.yaml
@@ -38,3 +38,4 @@ anyOf:
 - required:
   - schema:startTime
   - schema:endTime
+additionalProperties: false

--- a/schema/TrackingRequest/v2.0/attributes.yaml
+++ b/schema/TrackingRequest/v2.0/attributes.yaml
@@ -24,3 +24,4 @@ properties:
     $ref: "https://json-schema.org/draft/2020-12/schema"
 required:
 - id
+additionalProperties: false


### PR DESCRIPTION
Fixes #6

## Summary

Added `additionalProperties: false` to 25 `type: object` schemas that were missing it, making them closed schemas with strict validation.

## Schemas fixed

`CancellationOutcome`, `CancellationPolicy`, `CancellationReason`, `CatalogProcessingResult`, `CategoryCode`, `Context`, `ContractItem`, `Descriptor`, `DisplayedRating`, `Document`, `Eligibility`, `Error`, `ErrorResponse`, `Feedback`, `Intent`, `MediaFile`, `PaymentTerms`, `RatingForm`, `RatingInput`, `RefundTerms`, `SupportTicket`, `TimePeriod`, `TrackingRequest`, `CallbackAction`, `RequestAction`

## Schemas intentionally left open (`additionalProperties: true`)

`Attributes`, `Credential`, `GeoJSONGeometry`, `PriceSpecification`, `ProcessingNotice`, `SettlementTerm`, `SupportInfo`, `Entitlement`, and all action/callback schemas — these are intentionally extensible and their openness is by design.

## Schemas not applicable

`AcceptedPaymentMethod` (`type: array`), `CheckoutTerminal` (`type: string`), `PaymentTrigger` (`type: string`), `TransactionEndpoint` (`allOf`-based composition) — `additionalProperties` does not apply to non-object schemas.
