### PR TITLE
fix(#5): correct Provider @context URL; fix FulfillmentStage @type wrong class name

### DIFF
--- a/schema/FulfillmentStage/v2.0/attributes.yaml
+++ b/schema/FulfillmentStage/v2.0/attributes.yaml
@@ -11,7 +11,7 @@ properties:
     const: "https://schema.beckn.io/"
   '@type':
     type: string
-    default: beckn:FulfillmentStageEndpoint
+    default: beckn:FulfillmentStage
   id:
     description: A unique identifier for this stage of fulfillment
     type: string

--- a/schema/Provider/v2.0/attributes.yaml
+++ b/schema/Provider/v2.0/attributes.yaml
@@ -8,7 +8,7 @@ properties:
     description: CPD
     type: string
     format: uri
-    default: "https://schema.beckn.io/v2"
+    default: "https://schema.beckn.io/"
   '@type':
     description: TPD
     type: string


### PR DESCRIPTION
Fixes #5 (partial — see note below)

## Changes

### `schema/Provider/v2.0/attributes.yaml`

`@context` had the wrong URL — `https://schema.beckn.io/v2` instead of the correct `https://schema.beckn.io/`:

```diff
- default: "https://schema.beckn.io/v2"
+ default: "https://schema.beckn.io/"
```

### `schema/FulfillmentStage/v2.0/attributes.yaml`

`@type` default value named the wrong class — `beckn:FulfillmentStageEndpoint` instead of `beckn:FulfillmentStage`:

```diff
- default: beckn:FulfillmentStageEndpoint
+ default: beckn:FulfillmentStage
```

## Note on broader @context/@type design

The broader inconsistency in Issue #5 (mix of `const:` and `default:` across schemas, and whether `@context`/`@type` should accept arrays for domain extensibility) is tracked as Issue #16. That change requires an RFC and will be handled separately.
