### PR TITLE
fix(Credential/v2.0): tighten oneOf discriminator to fix ambiguous match

### DIFF
--- a/schema/Credential/v2.0/attributes.yaml
+++ b/schema/Credential/v2.0/attributes.yaml
@@ -20,6 +20,9 @@ components:
         description: A W3C Verifiable Credential as per the W3C VC Data Model. Treated as an opaque object at the schema layer.
         type: object
         additionalProperties: true
+        required:
+        - "@context"
+        - type
       - title: Document Credential
         description: A document attachment used as a credential.
         $ref: https://schema.beckn.io/Document/v2.0/attributes.yaml#/components/schemas/Document


### PR DESCRIPTION
The W3C VC branch had no required fields, causing any Document object (which is a plain object) to satisfy both oneOf branches and trigger 'input matches more than one oneOf schema' validation errors.

Fix: add required: ["@context", type] to the W3C VC branch. Both fields are MUST-level requirements in the W3C VC Data Model v2.0 (https://www.w3.org/TR/vc-data-model-2.0/) — every VC carries them, no Document ever would.

The Document branch already enforces required: [label, url, mimeType] via its $ref, so no change is needed there.

No new fields. No payload changes required. Fully backward-compatible.

Fixes: beckn/protocol-specifications-v2#162