### PR TITLE
fix(SettlementTerm): open enum for acceptedPaymentMethods + add UPI, PAYMENT_URL

### DIFF
--- a/schema/SettlementTerm/v2.0/attributes.yaml
+++ b/schema/SettlementTerm/v2.0/attributes.yaml
@@ -72,11 +72,15 @@ components:
             in the payTo property) for the purpose of this settlement.
           type: array
           items:
-            type: string
-            enum:
-            - CASH_DEPOSIT
-            - BANK_TRANSFER
-            additionalProperties: true
+            anyOf:
+            - type: string
+              enum:
+              - CASH_DEPOSIT
+              - BANK_TRANSFER
+              - UPI
+              - PAYMENT_URL
+            - type: string
+              description: Extension payment method not covered by the standard enum.
         settlementTermAttributes:
           description: Additional use case specific settlement terms that must be
             adhered to


### PR DESCRIPTION
## Problem

`acceptedPaymentMethods` used `additionalProperties: true` on a `type: string` item to signal extensibility, but this is a **no-op** in JSON Schema — that keyword only applies to objects, not strings. Validators correctly enforced the two-value enum `[CASH_DEPOSIT, BANK_TRANSFER]` and rejected any extension values (e.g. `"UPI"`).

## Fix

Switch to the standard **open-enum pattern** using `anyOf`:

```yaml
items:
  anyOf:
  - type: string
    enum: [CASH_DEPOSIT, BANK_TRANSFER, UPI, PAYMENT_URL]
  - type: string          # allows any extension value
```

This means:
- The known values are still documented and discoverable
- Any string not in the enum also passes validation (true extensibility)

## New enum values

| Value | When to use |
|---|---|
| `UPI` | Payment via UPI — pairs with `payTo.vpa` (e.g. `"sellerplatform@hdfc"`) |
| `PAYMENT_URL` | Hosted checkout page — pairs with `payTo.paymentUrl`; gateway handles method selection |

## Relationship to `payTo` variants

```
payTo.accountNumber  →  acceptedPaymentMethods: ["BANK_TRANSFER"]
payTo.vpa            →  acceptedPaymentMethods: ["UPI"]
payTo.paymentUrl     →  acceptedPaymentMethods: ["PAYMENT_URL"] or multiple
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)