### PR TITLE
fix: update references to LogisticsPlace in LogisticsRoute and Shipment schemas

### DIFF
--- a/schema/LogisticsRoute/v2.0/attributes.yaml
+++ b/schema/LogisticsRoute/v2.0/attributes.yaml
@@ -31,9 +31,9 @@ components:
           description: Human-readable route name
           example: Bangalore to Delhi via Hyderabad
         origin:
-          $ref: https://schema.beckn.io/Place/v2.0/attributes.yaml#/components/schemas/Place
+          $ref: https://schema.beckn.io/LogisticsPlace/v2.0/attributes.yaml#/components/schemas/LogisticsPlace
         destination:
-          $ref: https://schema.beckn.io/Place/v2.0/attributes.yaml#/components/schemas/Place
+          $ref: https://schema.beckn.io/LogisticsPlace/v2.0/attributes.yaml#/components/schemas/LogisticsPlace
         waypoints:
           type: array
           description: Intermediate waypoints/hubs on the route

--- a/schema/Shipment/v2.0/attributes.yaml
+++ b/schema/Shipment/v2.0/attributes.yaml
@@ -47,9 +47,9 @@ components:
           - CANCELLED
           example: IN_TRANSIT
         origin:
-          $ref: https://schema.beckn.io/Place/v2.0/attributes.yaml#/components/schemas/Place
+          $ref: https://schema.beckn.io/LogisticsPlace/v2.0/attributes.yaml#/components/schemas/LogisticsPlace
         destination:
-          $ref: https://schema.beckn.io/Place/v2.0/attributes.yaml#/components/schemas/Place
+          $ref: https://schema.beckn.io/LogisticsPlace/v2.0/attributes.yaml#/components/schemas/LogisticsPlace
         packages:
           type: array
           description: List of packages in this shipment


### PR DESCRIPTION
`LogisticsRoute` and `Shipment` schemas references a non-existent `Place` schema (`https://schema.beckn.io/Place/v2.0/attributes.yaml#/components/schemas/Place`)

This was updated to reference `LogisticsPlace` (`https://schema.beckn.io/LogisticsPlace/v2.0/attributes.yaml#/components/schemas/LogisticsPlace`)