### PR TITLE
fix: update reference to Receipt schema in Shipment attributes to LogisticsReceipt

### DIFF
--- a/schema/Shipment/v2.0/attributes.yaml
+++ b/schema/Shipment/v2.0/attributes.yaml
@@ -96,7 +96,7 @@ components:
         fare:
           $ref: https://schema.beckn.io/Fare/v2.0/attributes.yaml#/components/schemas/Fare
         receipt:
-          $ref: https://schema.beckn.io/Receipt/v2.0/attributes.yaml#/components/schemas/Receipt
+          $ref: https://schema.beckn.io/LogisticsReceipt/v2.0/attributes.yaml#/components/schemas/LogisticsReceipt
         cancellationPolicy:
           $ref: https://schema.beckn.io/CancellationPolicy/v2.0/attributes.yaml#/components/schemas/CancellationPolicy
         returnPolicy:


### PR DESCRIPTION
`Shipment` schema wrongly referenced `Receipt` instead of `LogisticsReceipt`. This is fixed in this PR.