### PR TITLE
 fix: update Place schema references to LogisticsPlace in logistics schemas

### DIFF
--- a/schema/Courier/v2.0/attributes.yaml
+++ b/schema/Courier/v2.0/attributes.yaml
@@ -62,7 +62,7 @@ components:
           description: Vehicle registration number
           example: KA05AB1234
         currentLocation:
-          $ref: https://schema.beckn.io/Place/v2.0/attributes.yaml#/components/schemas/Place
+          $ref: https://schema.beckn.io/LogisticsPlace/v2.0/attributes.yaml#/components/schemas/LogisticsPlace
         status:
           type: string
           enum:

--- a/schema/Hub/v2.0/attributes.yaml
+++ b/schema/Hub/v2.0/attributes.yaml
@@ -33,7 +33,7 @@ components:
           description: Short hub code
           example: BLR-MAIN
         place:
-          $ref: https://schema.beckn.io/Place/v2.0/attributes.yaml#/components/schemas/Place
+          $ref: https://schema.beckn.io/LogisticsPlace/v2.0/attributes.yaml#/components/schemas/LogisticsPlace
         type:
           type: string
           enum:

--- a/schema/ReturnPolicy/v2.0/attributes.yaml
+++ b/schema/ReturnPolicy/v2.0/attributes.yaml
@@ -63,4 +63,4 @@ components:
           type: boolean
           example: true
         returnHubAddress:
-          $ref: https://schema.beckn.io/Place/v2.0/attributes.yaml#/components/schemas/Place
+          $ref: https://schema.beckn.io/LogisticsPlace/v2.0/attributes.yaml#/components/schemas/LogisticsPlace

--- a/schema/Waypoint/v2.0/attributes.yaml
+++ b/schema/Waypoint/v2.0/attributes.yaml
@@ -28,7 +28,7 @@ components:
           type: string
           example: Hyderabad Sorting Hub
         place:
-          $ref: https://schema.beckn.io/Place/v2.0/attributes.yaml#/components/schemas/Place
+          $ref: https://schema.beckn.io/LogisticsPlace/v2.0/attributes.yaml#/components/schemas/LogisticsPlace
         type:
           type: string
           enum:


### PR DESCRIPTION
### Summary

Updated `$ref` references from the generic `Place` schema to the logistics-specific `LogisticsPlace` schema across four logistics domain attribute files.

### Changes

| File | Field Updated |
|------|--------------|
| `schema/Courier/v2.0/attributes.yaml` | `currentLocation` |
| `schema/Hub/v2.0/attributes.yaml` | `place` |
| `schema/ReturnPolicy/v2.0/attributes.yaml` | `returnHubAddress` |
| `schema/Waypoint/v2.0/attributes.yaml` | `place` |

### Details

All four files had `$ref` pointing to `https://schema.beckn.io/Place/v2.0/attributes.yaml#/components/schemas/Place`. These have been updated to reference `https://schema.beckn.io/LogisticsPlace/v2.0/attributes.yaml#/components/schemas/LogisticsPlace` to align with the logistics domain schema conventions introduced in prior PRs (#53, #54).

### Related PRs

- #53 — Updated references to `LogisticsPlace` in `LogisticsRoute` and `Shipment`
- #54 — Updated `Receipt` reference to `LogisticsReceipt` in `Shipment`
