### PR TITLE
fix: sync $ref URLs in schema.json files to match updated attributes.yaml references

### DIFF
--- a/schema/Courier/v2.0/schema.json
+++ b/schema/Courier/v2.0/schema.json
@@ -57,7 +57,7 @@
       "example": "KA05AB1234"
     },
     "currentLocation": {
-      "$ref": "https://schema.beckn.io/Place/v2.0/schema.json"
+      "$ref": "https://schema.beckn.io/LogisticsPlace/v2.0/schema.json"
     },
     "status": {
       "type": "string",

--- a/schema/Hub/v2.0/schema.json
+++ b/schema/Hub/v2.0/schema.json
@@ -22,7 +22,7 @@
       "example": "BLR-MAIN"
     },
     "place": {
-      "$ref": "https://schema.beckn.io/Place/v2.0/schema.json"
+      "$ref": "https://schema.beckn.io/LogisticsPlace/v2.0/schema.json"
     },
     "type": {
       "type": "string",

--- a/schema/LogisticsRoute/v2.0/schema.json
+++ b/schema/LogisticsRoute/v2.0/schema.json
@@ -19,10 +19,10 @@
       "example": "Bangalore to Delhi via Hyderabad"
     },
     "origin": {
-      "$ref": "https://schema.beckn.io/Place/v2.0/schema.json"
+      "$ref": "https://schema.beckn.io/LogisticsPlace/v2.0/schema.json"
     },
     "destination": {
-      "$ref": "https://schema.beckn.io/Place/v2.0/schema.json"
+      "$ref": "https://schema.beckn.io/LogisticsPlace/v2.0/schema.json"
     },
     "waypoints": {
       "type": "array",

--- a/schema/ReturnPolicy/v2.0/schema.json
+++ b/schema/ReturnPolicy/v2.0/schema.json
@@ -67,7 +67,7 @@
       "example": true
     },
     "returnHubAddress": {
-      "$ref": "https://schema.beckn.io/Place/v2.0/schema.json"
+      "$ref": "https://schema.beckn.io/LogisticsPlace/v2.0/schema.json"
     }
   },
   "$id": "https://schema.beckn.io/ReturnPolicy/v2.0",

--- a/schema/Shipment/v2.0/schema.json
+++ b/schema/Shipment/v2.0/schema.json
@@ -37,10 +37,10 @@
       "example": "IN_TRANSIT"
     },
     "origin": {
-      "$ref": "https://schema.beckn.io/Place/v2.0/schema.json"
+      "$ref": "https://schema.beckn.io/LogisticsPlace/v2.0/schema.json"
     },
     "destination": {
-      "$ref": "https://schema.beckn.io/Place/v2.0/schema.json"
+      "$ref": "https://schema.beckn.io/LogisticsPlace/v2.0/schema.json"
     },
     "packages": {
       "type": "array",
@@ -103,7 +103,7 @@
       "$ref": "https://schema.beckn.io/Fare/v2.0/schema.json"
     },
     "receipt": {
-      "$ref": "https://schema.beckn.io/Receipt/v2.0/schema.json"
+      "$ref": "https://schema.beckn.io/LogisticsReceipt/v2.0/schema.json"
     },
     "cancellationPolicy": {
       "$ref": "https://schema.beckn.io/CancellationPolicy/v2.0/schema.json"

--- a/schema/Waypoint/v2.0/schema.json
+++ b/schema/Waypoint/v2.0/schema.json
@@ -16,7 +16,7 @@
       "example": "Hyderabad Sorting Hub"
     },
     "place": {
-      "$ref": "https://schema.beckn.io/Place/v2.0/schema.json"
+      "$ref": "https://schema.beckn.io/LogisticsPlace/v2.0/schema.json"
     },
     "type": {
       "type": "string",


### PR DESCRIPTION
### Summary

Six `schema.json` files had stale `$ref` URLs still pointing to the deprecated `Place` and `Receipt` schemas, out of sync with `attributes.yaml` files that were already updated in prior PRs (#53, #54, and #55).

### Changes

| File | Property | Old `$ref` | New `$ref` |
|------|----------|-----------|-----------|
| `schema/Courier/v2.0/schema.json` | `currentLocation` | `Place/v2.0/schema.json` | `LogisticsPlace/v2.0/schema.json` |
| `schema/Hub/v2.0/schema.json` | `place` | `Place/v2.0/schema.json` | `LogisticsPlace/v2.0/schema.json` |
| `schema/ReturnPolicy/v2.0/schema.json` | `returnHubAddress` | `Place/v2.0/schema.json` | `LogisticsPlace/v2.0/schema.json` |
| `schema/Waypoint/v2.0/schema.json` | `place` | `Place/v2.0/schema.json` | `LogisticsPlace/v2.0/schema.json` |
| `schema/LogisticsRoute/v2.0/schema.json` | `origin`, `destination` | `Place/v2.0/schema.json` | `LogisticsPlace/v2.0/schema.json` |
| `schema/Shipment/v2.0/schema.json` | `origin`, `destination` | `Place/v2.0/schema.json` | `LogisticsPlace/v2.0/schema.json` |
| `schema/Shipment/v2.0/schema.json` | `receipt` | `Receipt/v2.0/schema.json` | `LogisticsReceipt/v2.0/schema.json` |

### Related PRs

- #53 — Updated `attributes.yaml` references to `LogisticsPlace` in `LogisticsRoute` and `Shipment`
- #54 — Updated `attributes.yaml` reference to `LogisticsReceipt` in `Shipment`
- #55 — Updated remaining `attributes.yaml` files (`Courier`, `Hub`, `ReturnPolicy`, `Waypoint`)
