### PR TITLE
feat(hiring-common): add JobLocation, SalarySpecification, Reputation…

### DIFF
--- a/schema/JobLocation/README.md
+++ b/schema/JobLocation/README.md
@@ -1,0 +1,21 @@
+# JobLocation
+
+**Container:** inline sub-schema (shared utility type)
+**Tag:** hiring hiring-common shared-type
+**Pack:** hiring-common
+**Use Cases:** Any hiring-domain network requiring location filtering on job listings or candidate profiles
+
+Flexible location type combining optional GeoJSON geometry and optional postal address fields. At least one must be present (anyOf constraint).
+
+Two modes:
+- **Text filtering** — `address_locality`, `address_region`, `address_country` for city/region-based discovery ("jobs in Bengaluru")
+- **Geo-spatial** — `geo` (GeoJSONGeometry) for radius-based queries via Beckn SpatialConstraint operators ("jobs within 50 km")
+
+Both modes may coexist on the same object for richer indexing.
+
+Used by:
+- `HiringJobResource.location` — work location of a job vacancy
+- `CandidateProfileResource.preferred_location` / `current_location` — candidate location preferences
+- `DriverCandidateProfileResource.home_location` — driver home location (locality-level only at discovery)
+
+Note: `geo` MUST be locality-level precision at on_discover — precise GPS coordinates MUST NOT be disclosed until a later stage.

--- a/schema/JobLocation/v2.1/README.md
+++ b/schema/JobLocation/v2.1/README.md
@@ -1,0 +1,15 @@
+# JobLocation — v2.1
+
+**Schema Pack Version:** 2.1.0
+**Released:** July 2026
+**Status:** Initial release
+
+## Notes
+
+Initial release of the JobLocation shared utility type for the hiring domain. Introduces the
+flexible anyOf location model combining GeoJSON geometry (`geo`) and postal address fields
+(`address_locality`, `address_region`, `address_country`), supporting both text-based
+discovery filtering and geo-spatial radius queries via Beckn SpatialConstraint operators.
+
+Privacy constraint introduced at this version: `geo` MUST be locality-level precision at
+`on_discover` — precise GPS coordinates MUST NOT be disclosed until a later contract stage.

--- a/schema/JobLocation/v2.1/attributes.yaml
+++ b/schema/JobLocation/v2.1/attributes.yaml
@@ -1,0 +1,78 @@
+openapi: 3.1.1
+info:
+  title: JobLocation
+  version: "2.1.0"
+  description: >
+    Shared location sub-schema for hiring-domain schemas. Intentionally flexible:
+    supports both city/region text filtering (addressLocality, addressRegion,
+    addressCountry) and geo-spatial queries via GeoJSON geometry. Both branches
+    are optional individually but at least one must be provided (anyOf constraint).
+
+    Design rationale: The core Beckn Location type requires a geo field (GeoJSON
+    geometry), which is too strict for most hiring discovery use cases where BAPs
+    typically filter by city or region text rather than by radius. At the same time,
+    some operators (especially transport/logistics) need geo-spatial proximity
+    queries via Beckn SpatialConstraint operators. By making both branches optional
+    with anyOf, this type serves text-based discovery ("jobs in Bangalore") and
+    geo-spatial discovery ("jobs within 50 km of this point") without forcing
+    operators to collect precise coordinates for every listing.
+
+components:
+  schemas:
+    GeoJSONGeometry:
+      type: object
+      description: >
+        Minimal GeoJSON geometry fragment. Supports Point, Polygon, and other
+        GeoJSON geometry types as used by Beckn SpatialConstraint operators.
+      required: [type, coordinates]
+      properties:
+        type:
+          type: string
+          description: GeoJSON geometry type (e.g. Point, Polygon).
+          x-jsonld-id: "jloc:geoType"
+        coordinates:
+          description: >
+            GeoJSON coordinates array. For a Point: [longitude, latitude].
+            For a Polygon: array of linear rings.
+          x-jsonld-id: "jloc:coordinates"
+
+    JobLocation:
+      type: object
+      x-beckn-shared-type: true
+      x-status: under-review
+      x-tags:
+        - hiring
+        - hiring-common
+        - shared-type
+      description: >
+        Flexible hiring location. Supports city/region text filtering (most common
+        use case) and GeoJSON geo-spatial queries. Either geo or at least one
+        address field must be present; both may coexist for richer indexing.
+      anyOf:
+        - required: [geo]
+        - required: [address_locality]
+        - required: [address_region]
+        - required: [address_country]
+      properties:
+        geo:
+          $ref: "#/components/schemas/GeoJSONGeometry"
+          description: >
+            GeoJSON geometry for spatial queries. MUST be locality-level precision
+            at on_discover (not precise address). Use for SpatialConstraint operators.
+          x-jsonld-id: "jloc:geo"
+        address_locality:
+          type: string
+          description: City or locality name (e.g. "Bengaluru", "Mumbai").
+          x-jsonld-id: "jloc:address_locality"
+        address_region:
+          type: string
+          description: State or province (e.g. "Karnataka", "Maharashtra").
+          x-jsonld-id: "jloc:address_region"
+        postal_code:
+          type: string
+          description: Postal or PIN code.
+          x-jsonld-id: "jloc:postal_code"
+        address_country:
+          type: string
+          description: ISO 3166-1 alpha-2 country code (e.g. "IN", "US").
+          x-jsonld-id: "jloc:address_country"

--- a/schema/JobLocation/v2.1/context.jsonld
+++ b/schema/JobLocation/v2.1/context.jsonld
@@ -1,0 +1,30 @@
+{
+  "@context": {
+    "schema": "https://schema.org/",
+    "beckn": "https://schema.beckn.io/",
+    "jloc": "https://schema.beckn.io/JobLocation#",
+    "JobLocation": "jloc:JobLocation",
+    "GeoJSONGeometry": "jloc:GeoJSONGeometry",
+    "geo": {
+      "@id": "jloc:geo"
+    },
+    "geoType": {
+      "@id": "jloc:geoType"
+    },
+    "coordinates": {
+      "@id": "jloc:coordinates"
+    },
+    "address_locality": {
+      "@id": "jloc:address_locality"
+    },
+    "address_region": {
+      "@id": "jloc:address_region"
+    },
+    "postal_code": {
+      "@id": "jloc:postal_code"
+    },
+    "address_country": {
+      "@id": "jloc:address_country"
+    }
+  }
+}

--- a/schema/JobLocation/v2.1/vocab.jsonld
+++ b/schema/JobLocation/v2.1/vocab.jsonld
@@ -1,0 +1,55 @@
+{
+  "@context": {
+    "jloc": "https://schema.beckn.io/JobLocation#",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#"
+  },
+  "@graph": [
+    {
+      "@id": "jloc:JobLocation",
+      "@type": "rdfs:Class",
+      "rdfs:label": "JobLocation",
+      "rdfs:comment": "Flexible hiring location supporting text-based and geo-spatial filtering."
+    },
+    {
+      "@id": "jloc:geo",
+      "@type": "rdf:Property",
+      "rdfs:label": "geo",
+      "rdfs:comment": "GeoJSON geometry for spatial queries.",
+      "rdfs:domain": {"@id": "jloc:JobLocation"}
+    },
+    {
+      "@id": "jloc:address_locality",
+      "@type": "rdf:Property",
+      "rdfs:label": "address_locality",
+      "rdfs:comment": "City or locality name.",
+      "rdfs:domain": {"@id": "jloc:JobLocation"},
+      "rdfs:range": {"@id": "xsd:string"}
+    },
+    {
+      "@id": "jloc:address_region",
+      "@type": "rdf:Property",
+      "rdfs:label": "address_region",
+      "rdfs:comment": "State or province.",
+      "rdfs:domain": {"@id": "jloc:JobLocation"},
+      "rdfs:range": {"@id": "xsd:string"}
+    },
+    {
+      "@id": "jloc:postal_code",
+      "@type": "rdf:Property",
+      "rdfs:label": "postal_code",
+      "rdfs:comment": "Postal or PIN code.",
+      "rdfs:domain": {"@id": "jloc:JobLocation"},
+      "rdfs:range": {"@id": "xsd:string"}
+    },
+    {
+      "@id": "jloc:address_country",
+      "@type": "rdf:Property",
+      "rdfs:label": "address_country",
+      "rdfs:comment": "ISO 3166-1 alpha-2 country code.",
+      "rdfs:domain": {"@id": "jloc:JobLocation"},
+      "rdfs:range": {"@id": "xsd:string"}
+    }
+  ]
+}

--- a/schema/ReputationSummary/README.md
+++ b/schema/ReputationSummary/README.md
@@ -1,0 +1,13 @@
+# ReputationSummary
+
+**Container:** inline sub-schema (shared utility type)
+**Tag:** hiring hiring-common shared-type
+**Pack:** hiring-common
+**Use Cases:** Any hiring-domain network requiring reputation signals
+
+Attestation-based reputation capsule shared across hiring-domain schemas:
+- `HiringJobResource.operator_reputation` — organisation/operator reputation
+- `CandidateProfileResource.reputation_summary` — candidate reputation
+
+No PII. Safe to expose at discovery stage.
+Upstream candidate for promotion to beckn core common types.

--- a/schema/ReputationSummary/v2.1/README.md
+++ b/schema/ReputationSummary/v2.1/README.md
@@ -1,0 +1,13 @@
+# ReputationSummary — v2.1
+
+**Schema Pack Version:** 2.1.0
+**Released:** July 2026
+**Status:** Initial release
+
+## Notes
+
+Initial release of the ReputationSummary shared utility type for the hiring domain. Provides
+an attestation-based reputation capsule that is safe to expose at discovery stage (no PII).
+
+Identified as an upstream candidate for promotion to Beckn core common types given its
+domain-neutral structure.

--- a/schema/ReputationSummary/v2.1/attributes.yaml
+++ b/schema/ReputationSummary/v2.1/attributes.yaml
@@ -1,0 +1,38 @@
+openapi: 3.1.1
+info:
+  title: ReputationSummary
+  version: "2.1.0"
+  description: >
+    Shared attestation-based reputation sub-schema for any hiring-domain schema.
+    Represents aggregated reputation data sourced from verified network ratings.
+    Applicable to both organisations (operator_reputation on job resources) and
+    candidates (reputation_summary on candidate profile resources).
+
+components:
+  schemas:
+    ReputationSummary:
+      type: object
+      x-status: under-review
+      x-tags:
+        - hiring
+        - hiring-common
+        - shared-type
+      description: >
+        Attestation-based reputation capsule. No centralised score — rating_value
+        is attested by the named rating_agency.
+      properties:
+        rating_value:
+          type: number
+          minimum: 0
+          maximum: 5
+          description: Aggregate attested rating on a 0–5 scale.
+          x-jsonld-id: "rsa:rating_value"
+        rating_count:
+          type: integer
+          minimum: 0
+          description: Number of attested ratings backing rating_value.
+          x-jsonld-id: "rsa:rating_count"
+        rating_agency:
+          type: string
+          description: Name or DID of the agency that attested the rating.
+          x-jsonld-id: "rsa:rating_agency"

--- a/schema/ReputationSummary/v2.1/context.jsonld
+++ b/schema/ReputationSummary/v2.1/context.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "schema": "https://schema.org/",
+    "beckn": "https://schema.beckn.io/",
+    "rsa": "https://schema.beckn.io/ReputationSummary#",
+    "ReputationSummary": "rsa:ReputationSummary",
+    "rating_value": {
+      "@id": "rsa:rating_value"
+    },
+    "rating_count": {
+      "@id": "rsa:rating_count"
+    },
+    "rating_agency": {
+      "@id": "rsa:rating_agency"
+    }
+  }
+}

--- a/schema/ReputationSummary/v2.1/vocab.jsonld
+++ b/schema/ReputationSummary/v2.1/vocab.jsonld
@@ -1,0 +1,17 @@
+{
+  "@import": "https://schema.beckn.io/core/v2/vocab.jsonld",
+  "@context": {
+    "@import": "https://schema.beckn.io/core/v2/vocab.jsonld",
+    "rsa": "https://schema.beckn.io/ReputationSummary#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "ReputationSummary": "rsa:ReputationSummary"
+  },
+  "@graph": [
+    {
+      "@id": "rsa:ReputationSummary",
+      "@type": "rdfs:Class",
+      "rdfs:label": "Reputation Summary",
+      "rdfs:comment": "Attestation-based reputation capsule for hiring-domain entities."
+    }
+  ]
+}

--- a/schema/SalarySpecification/README.md
+++ b/schema/SalarySpecification/README.md
@@ -1,0 +1,20 @@
+# SalarySpecification
+
+**Container:** inline sub-schema (shared utility type)
+**Tag:** hiring hiring-common shared-type
+**Pack:** hiring-common
+**Use Cases:** Any hiring-domain network carrying salary data on job offers or candidate expectations
+
+Structured salary range (or fixed value) with currency and payment period. Replaces flat `salary_min` / `salary_max` / `salary_currency` / `salary_period` fields that were previously scattered across Offer and candidate schemas.
+
+Properties:
+- `salary_min` — minimum (or fixed) value
+- `salary_max` — maximum value for a range; omit for fixed salary
+- `salary_currency` — ISO 4217 code (e.g. INR, USD)
+- `salary_period` — ANNUAL, MONTHLY, WEEKLY, HOURLY, or PER_GIG
+
+The `PER_GIG` period variant accommodates gig and platform hiring networks where pay is per completed unit rather than a time period.
+
+Used by:
+- `HiringJobOffer.salary_specification` — compensation offered by the employer
+- `CandidateProfileResource.expected_salary` — salary expectation declared by the candidate

--- a/schema/SalarySpecification/v2.1/README.md
+++ b/schema/SalarySpecification/v2.1/README.md
@@ -1,0 +1,15 @@
+# SalarySpecification — v2.1
+
+**Schema Pack Version:** 2.1.0
+**Released:** July 2026
+**Status:** Initial release
+
+## Notes
+
+Initial release of the SalarySpecification shared utility type for the hiring domain. Replaces
+the flat `salary_min` / `salary_max` / `salary_currency` / `salary_period` fields that were
+previously scattered across Offer and candidate schemas, consolidating them into a single
+structured sub-object.
+
+Introduces the `PER_GIG` salary period variant to accommodate gig and platform hiring networks
+where pay is per completed unit rather than a recurring time period.

--- a/schema/SalarySpecification/v2.1/attributes.yaml
+++ b/schema/SalarySpecification/v2.1/attributes.yaml
@@ -1,0 +1,51 @@
+openapi: 3.1.1
+info:
+  title: SalarySpecification
+  version: "2.1.0"
+  description: >
+    Shared salary sub-schema for hiring-domain schemas. Captures a salary range
+    (or fixed value via min == max) with currency and payment period.
+
+    Design rationale: Salary data appears in two distinct contexts — job offers
+    (what the employer proposes) and candidate profiles (what the candidate
+    expects). Defining a single shared SalarySpecification type in hiring-common
+    eliminates duplication, ensures consistent field naming across both contexts,
+    and makes salary data machine-comparable for BAP-side matching. ISO 4217
+    currency codes and the PER_GIG period variant accommodate gig/platform
+    hiring networks alongside traditional employment.
+
+components:
+  schemas:
+    SalarySpecification:
+      type: object
+      x-beckn-shared-type: true
+      x-status: under-review
+      x-tags:
+        - hiring
+        - hiring-common
+        - shared-type
+      description: >
+        A salary range or fixed value with currency and payment period.
+        For a fixed salary set salary_min == salary_max, or provide only salary_min.
+      properties:
+        salary_min:
+          type: number
+          minimum: 0
+          description: Minimum (or fixed) salary value.
+          x-jsonld-id: "salspec:salary_min"
+        salary_max:
+          type: number
+          minimum: 0
+          description: Maximum salary value for a range offer. Omit for fixed salary.
+          x-jsonld-id: "salspec:salary_max"
+        salary_currency:
+          type: string
+          description: ISO 4217 currency code (e.g. INR, USD, EUR).
+          x-jsonld-id: "salspec:salary_currency"
+        salary_period:
+          type: string
+          enum: [ANNUAL, MONTHLY, WEEKLY, HOURLY, PER_GIG]
+          description: >
+            Payment recurrence basis. PER_GIG is for task-based or gig engagements
+            where pay is per completed unit rather than a time period.
+          x-jsonld-id: "salspec:salary_period"

--- a/schema/SalarySpecification/v2.1/context.jsonld
+++ b/schema/SalarySpecification/v2.1/context.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "schema": "https://schema.org/",
+    "beckn": "https://schema.beckn.io/",
+    "salspec": "https://schema.beckn.io/SalarySpecification#",
+    "SalarySpecification": "salspec:SalarySpecification",
+    "salary_min": {
+      "@id": "salspec:salary_min"
+    },
+    "salary_max": {
+      "@id": "salspec:salary_max"
+    },
+    "salary_currency": {
+      "@id": "salspec:salary_currency"
+    },
+    "salary_period": {
+      "@id": "salspec:salary_period"
+    },
+    "SalaryPeriod": "salspec:SalaryPeriod"
+  }
+}

--- a/schema/SalarySpecification/v2.1/vocab.jsonld
+++ b/schema/SalarySpecification/v2.1/vocab.jsonld
@@ -1,0 +1,48 @@
+{
+  "@context": {
+    "salspec": "https://schema.beckn.io/SalarySpecification#",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#"
+  },
+  "@graph": [
+    {
+      "@id": "salspec:SalarySpecification",
+      "@type": "rdfs:Class",
+      "rdfs:label": "SalarySpecification",
+      "rdfs:comment": "A salary range or fixed value with currency and payment period."
+    },
+    {
+      "@id": "salspec:salary_min",
+      "@type": "rdf:Property",
+      "rdfs:label": "salary_min",
+      "rdfs:comment": "Minimum (or fixed) salary value.",
+      "rdfs:domain": {"@id": "salspec:SalarySpecification"},
+      "rdfs:range": {"@id": "xsd:decimal"}
+    },
+    {
+      "@id": "salspec:salary_max",
+      "@type": "rdf:Property",
+      "rdfs:label": "salary_max",
+      "rdfs:comment": "Maximum salary value for a range offer.",
+      "rdfs:domain": {"@id": "salspec:SalarySpecification"},
+      "rdfs:range": {"@id": "xsd:decimal"}
+    },
+    {
+      "@id": "salspec:salary_currency",
+      "@type": "rdf:Property",
+      "rdfs:label": "salary_currency",
+      "rdfs:comment": "ISO 4217 currency code.",
+      "rdfs:domain": {"@id": "salspec:SalarySpecification"},
+      "rdfs:range": {"@id": "xsd:string"}
+    },
+    {
+      "@id": "salspec:salary_period",
+      "@type": "rdf:Property",
+      "rdfs:label": "salary_period",
+      "rdfs:comment": "Payment recurrence basis.",
+      "rdfs:domain": {"@id": "salspec:SalarySpecification"},
+      "rdfs:range": {"@id": "xsd:string"}
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds the \`hiring-common/\` folder with three shared utility types that are referenced across multiple hiring-domain schema packs.

| Schema | Referenced by |
|--------|--------------|
| \`JobLocation\` | \`HiringJobResource\`, \`CandidateProfileResource\` (×2), \`DriverCandidateProfileResource\` |
| \`SalarySpecification\` | \`HiringJobOffer\`, \`CandidateProfileResource\` |
| \`ReputationSummary\` | \`HiringJobResource\`, \`CandidateProfileResource\` |

Each schema includes:
- Schema-level \`README.md\` (identity, purpose, design rationale)
- \`v2.1/README.md\` version stub
- \`attributes.yaml\`, \`context.jsonld\`, \`vocab.jsonld\`

All schemas carry \`x-status: under-review\`.