### PR TITLE
fix: replace relative $ref paths with absolute schema.beckn.io URLs

### DIFF
--- a/schema/CandidateProfileResource/v2.1/attributes.yaml
+++ b/schema/CandidateProfileResource/v2.1/attributes.yaml
@@ -162,11 +162,11 @@ components:
           description: Candidate's preferred work arrangement
           x-jsonld-id: "cpra:preferredWorkMode"
         preferred_location:
-          $ref: "../../../hiring-common/JobLocation/v2.1/attributes.yaml#/components/schemas/JobLocation"
+          $ref: "https://schema.beckn.io/JobLocation/v2.1/attributes.yaml#/components/schemas/JobLocation"
           description: Candidate's preferred work location (city/region level or geo-spatial)
           x-jsonld-id: "cpra:preferredLocation"
         current_location:
-          $ref: "../../../hiring-common/JobLocation/v2.1/attributes.yaml#/components/schemas/JobLocation"
+          $ref: "https://schema.beckn.io/JobLocation/v2.1/attributes.yaml#/components/schemas/JobLocation"
           description: Candidate's current location (city/country level only — not precise)
           x-jsonld-id: "cpra:currentLocation"
         relocation_willing:
@@ -200,7 +200,7 @@ components:
           description: Preferred job functions (e.g. Engineering, Marketing)
           x-jsonld-id: "cpra:functionalAreaPreference"
         expected_salary:
-          $ref: "../../../hiring-common/SalarySpecification/v2.1/attributes.yaml#/components/schemas/SalarySpecification"
+          $ref: "https://schema.beckn.io/SalarySpecification/v2.1/attributes.yaml#/components/schemas/SalarySpecification"
           description: Expected salary range with currency and period
           x-jsonld-id: "cpra:expectedSalary"
         languages:
@@ -217,7 +217,7 @@ components:
           description: Job engagement types the candidate is open to
           x-jsonld-id: "cpra:openToJobTypes"
         reputation_summary:
-          $ref: "../../../hiring-common/ReputationSummary/v2.1/attributes.yaml#/components/schemas/ReputationSummary"
+          $ref: "https://schema.beckn.io/ReputationSummary/v2.1/attributes.yaml#/components/schemas/ReputationSummary"
           description: >
             Attested reputation summary for this candidate, sourced from
             network-verified ratings. Safe at discovery stage — no PII.

--- a/schema/HiringJobOffer/v2.1/attributes.yaml
+++ b/schema/HiringJobOffer/v2.1/attributes.yaml
@@ -30,7 +30,7 @@ components:
         hiring verticals (transport, construction, hospitality).
       properties:
         salary_specification:
-          $ref: "../../../hiring-common/SalarySpecification/v2.1/attributes.yaml#/components/schemas/SalarySpecification"
+          $ref: "https://schema.beckn.io/SalarySpecification/v2.1/attributes.yaml#/components/schemas/SalarySpecification"
           description: Structured salary range with currency and period.
           x-jsonld-id: "hjoa:salary_specification"
         benefits:

--- a/schema/HiringJobResource/v2.1/attributes.yaml
+++ b/schema/HiringJobResource/v2.1/attributes.yaml
@@ -42,7 +42,7 @@ components:
           description: Physical location model for the role.
           x-jsonld-id: "hjra:work_mode"
         location:
-          $ref: "../../../hiring-common/JobLocation/v2.1/attributes.yaml#/components/schemas/JobLocation"
+          $ref: "https://schema.beckn.io/JobLocation/v2.1/attributes.yaml#/components/schemas/JobLocation"
           description: Work location using the shared JobLocation type.
           x-jsonld-id: "hjra:location"
         shift_type:
@@ -91,11 +91,11 @@ components:
         requirements:
           type: array
           items:
-            $ref: "../../../../common/CredentialRequirement/v2.1/attributes.yaml#/components/schemas/CredentialRequirement"
+            $ref: "https://schema.beckn.io/CredentialRequirement/v2.1/attributes.yaml#/components/schemas/CredentialRequirement"
           description: Credential or certification prerequisites.
           x-jsonld-id: "hjra:requirements"
         industry_type:
-          $ref: "../../../../common/CodedValue/v2.1/attributes.yaml#/components/schemas/CodedValue"
+          $ref: "https://schema.beckn.io/CodedValue/v2.1/attributes.yaml#/components/schemas/CodedValue"
           description: Industry classification (e.g. ISIC authority code).
           x-jsonld-id: "hjra:industry_type"
         functional_area:
@@ -124,7 +124,7 @@ components:
           x-pii-disclosure-stage: on_select
           x-jsonld-id: "hjra:application_instructions"
         operator_reputation:
-          $ref: "../../../hiring-common/ReputationSummary/v2.1/attributes.yaml#/components/schemas/ReputationSummary"
+          $ref: "https://schema.beckn.io/ReputationSummary/v2.1/attributes.yaml#/components/schemas/ReputationSummary"
           description: >
             Attested reputation summary for the hiring organisation. Safe at
             discovery stage — no PII.

--- a/schema/JobApplicationContract/v2.1/attributes.yaml
+++ b/schema/JobApplicationContract/v2.1/attributes.yaml
@@ -84,7 +84,7 @@ components:
           description: Free-text notes from the recruiter.
           x-jsonld-id: "jaca:notes"
         prerequisite_verification_summary:
-          $ref: "../../../../common/VerificationSummary/v2.1/attributes.yaml#/components/schemas/VerificationSummary"
+          $ref: "https://schema.beckn.io/VerificationSummary/v2.1/attributes.yaml#/components/schemas/VerificationSummary"
           description: Outcome of credential verification checks.
           x-jsonld-id: "jaca:prerequisite_verification_summary"
         identity_reference:

--- a/schema/JobApplicationPerformance/v2.1/attributes.yaml
+++ b/schema/JobApplicationPerformance/v2.1/attributes.yaml
@@ -148,7 +148,7 @@ components:
           description: "Legacy: qualitative notes on the primary step outcome."
           x-jsonld-id: "japa:result_notes"
         verification_summary:
-          $ref: "../../../../common/VerificationSummary/v2.1/attributes.yaml#/components/schemas/VerificationSummary"
+          $ref: "https://schema.beckn.io/VerificationSummary/v2.1/attributes.yaml#/components/schemas/VerificationSummary"
           description: Credential verification outcome during this performance cycle.
           x-jsonld-id: "japa:verification_summary"
         next_step:


### PR DESCRIPTION
All hiring schemas are deployed as flat peers at schema.beckn.io, so relative paths (e.g. ../../../hiring-common/JobLocation/...) resolve to non-existent paths and return HTTP 404.

Replace all cross-schema $refs with canonical absolute URLs:

  JobLocation        → https://schema.beckn.io/JobLocation/v2.1/attributes.yaml
  SalarySpecification → https://schema.beckn.io/SalarySpecification/v2.1/attributes.yaml
  ReputationSummary  → https://schema.beckn.io/ReputationSummary/v2.1/attributes.yaml
  CredentialRequirement → https://schema.beckn.io/CredentialRequirement/v2.1/attributes.yaml
  CodedValue         → https://schema.beckn.io/CodedValue/v2.1/attributes.yaml
  VerificationSummary → https://schema.beckn.io/VerificationSummary/v2.1/attributes.yaml

Files changed (5):
  hiring-jobs/HiringJobResource          — 4 refs fixed
  hiring-jobs/HiringJobOffer             — 1 ref fixed
  hiring-jobs/JobApplicationContract     — 1 ref fixed
  hiring-jobs/JobApplicationPerformance  — 1 ref fixed
  hiring-candidates/CandidateProfileResource — 4 refs fixed