### PR TITLE
fix: replace local $ref pointers with absolute schema.beckn.io URLs

### DIFF
--- a/schema/Offer/v2.1/attributes.yaml
+++ b/schema/Offer/v2.1/attributes.yaml
@@ -35,7 +35,7 @@ components:
           type: array
           description: References (IDs) to resources covered by this offer.
           items:
-            $ref: '#/components/schemas/Resource/properties/id'
+            $ref: https://schema.beckn.io/Resource/v2.0/attributes.yaml#/components/schemas/Resource/properties/id
         addOns:
           type: array
           description: IDs of optional extra Offers or Resources that can be attached.
@@ -44,7 +44,7 @@ components:
         considerationIds:
           type: array
           items:
-            $ref: '#/components/schemas/Consideration/properties/id'
+            $ref: https://schema.beckn.io/Consideration/v2.0/attributes.yaml#/components/schemas/Consideration/properties/id
         fulfillmentIds:
           description: Details regarding the fulfillment of this offer
           $ref: https://schema.beckn.io/Consideration/v2.0/attributes.yaml#/components/schemas/Consideration

--- a/schema/Performance/v2.0/attributes.yaml
+++ b/schema/Performance/v2.0/attributes.yaml
@@ -57,7 +57,7 @@ components:
         commitmentIds:
           type: array
           items:
-            $ref: '#/components/schemas/Commitment/properties/id'
+            $ref: https://schema.beckn.io/Commitment/v2.0/attributes.yaml#/components/schemas/Commitment/properties/id
         performanceAttributes:
           description: Domain-specific extension attributes for this fulfillment.
             Use beckn:HyperlocalDelivery (aligned with schema:ParcelDelivery) for

--- a/schema/Settlement/v2.0/attributes.yaml
+++ b/schema/Settlement/v2.0/attributes.yaml
@@ -17,7 +17,7 @@ components:
         id:
           type: string
         considerationId:
-          $ref: '#/components/schemas/Consideration/properties/id'
+          $ref: https://schema.beckn.io/Consideration/v2.0/attributes.yaml#/components/schemas/Consideration/properties/id
         status:
           type: string
           enum:


### PR DESCRIPTION
## Summary
Three schema files used local `#/components/schemas/...` `$ref` pointers to reference schemas (`Resource`, `Consideration`, `Commitment`) that aren't actually defined in the same file — each of those lives in its own standalone file per this repo's structure (docs/2_Schema_Structure.md §4.4), so the refs were unresolvable and broke validators (#64).

- `schema/Offer/v2.1/attributes.yaml` — `resourceIds` → `Resource`, `considerationIds` → `Consideration`
- `schema/Performance/v2.0/attributes.yaml` — `commitmentIds` → `Commitment`
- `schema/Settlement/v2.0/attributes.yaml` — `considerationId` → `Consideration`

All four are replaced with absolute `https://schema.beckn.io/...` URLs pointing at the correct schema's `id` property, matching the convention already used elsewhere in these same files.

Closes #64

## Test plan
- [x] Confirmed no remaining broken `$ref: '#/...'` local pointers in the affected files
- [x] YAML validated as well-formed for all three files
- [x] Confirmed each new URL resolves to a schema that defines an `id` property (`Resource/v2.0`, `Consideration/v2.0`, `Commitment/v2.0`)
