### PR TITLE
Add PriceComponent/v2.2 and fix mobility schema hygiene

### DIFF
--- a/schema/Authority/v2.0/README.md
+++ b/schema/Authority/v2.0/README.md
@@ -27,6 +27,5 @@ A governmental or administrative body responsible for planning, regulating, and 
 | `categories` | no | $ref: https://schema.beckn.io/CategoryCode/v2.1/attributes.yaml#/components/schemas/CategoryCode | Service categories offered by the provider |
 | `locations` | no | $ref: https://schema.beckn.io/Location/v2.0/attributes.yaml#/components/schemas/Location | Locations where the provider offers services |
 | `items` | no | $ref: https://schema.beckn.io/Item/v2.1/attributes.yaml#/components/schemas/Item | Items available for discovery from this provider |
-| `fulfillments` | no | $ref: https://schema.beckn.io/Fulfillment/v2.1/attributes.yaml#/components/schemas/Fulfillment | Fulfillment options offered by this provider |
 | `ratingsTotal` | no | number | Total number of ratings received |
 | `rating` | no | $ref: https://schema.beckn.io/Rating/v2.0/attributes.yaml#/components/schemas/Rating | Aggregate rating of the provider |

--- a/schema/Authority/v2.0/attributes.yaml
+++ b/schema/Authority/v2.0/attributes.yaml
@@ -46,9 +46,6 @@ components:
         items:
           description: Items available for discovery from this provider
           $ref: https://schema.beckn.io/Item/v2.1/attributes.yaml#/components/schemas/Item
-        fulfillments:
-          description: Fulfillment options offered by this provider
-          $ref: https://schema.beckn.io/Fulfillment/v2.1/attributes.yaml#/components/schemas/Fulfillment
         ratingsTotal:
           description: Total number of ratings received
           type: number

--- a/schema/Authority/v2.0/context.jsonld
+++ b/schema/Authority/v2.0/context.jsonld
@@ -10,7 +10,6 @@
     "categories": "beckn:categories",
     "locations": "beckn:locations",
     "items": "beckn:items",
-    "fulfillments": "beckn:fulfillments",
     "ratingsTotal": "beckn:ratingsTotal",
     "rating": "beckn:rating"
   }

--- a/schema/Authority/v2.0/schema.json
+++ b/schema/Authority/v2.0/schema.json
@@ -38,10 +38,6 @@
       "description": "Items available for discovery from this provider",
       "$ref": "https://schema.beckn.io/Item/v2.1/schema.json"
     },
-    "fulfillments": {
-      "description": "Fulfillment options offered by this provider",
-      "$ref": "https://schema.beckn.io/Fulfillment/v2.1/schema.json"
-    },
     "ratingsTotal": {
       "description": "Total number of ratings received",
       "type": "number"

--- a/schema/Authority/v2.0/vocab.jsonld
+++ b/schema/Authority/v2.0/vocab.jsonld
@@ -181,24 +181,6 @@
       }
     },
     {
-      "@id": "beckn:fulfillments",
-      "@type": "rdf:Property",
-      "rdfs:label": {
-        "@value": "fulfillments",
-        "@language": "en"
-      },
-      "rdfs:comment": {
-        "@value": "Fulfillment options offered by this provider",
-        "@language": "en"
-      },
-      "rdfs:domain": {
-        "@id": "beckn:Authority"
-      },
-      "rdfs:range": {
-        "@id": "https://schema.beckn.io/core/v2.0/#Fulfillment"
-      }
-    },
-    {
       "@id": "beckn:ratingsTotal",
       "@type": "rdf:Property",
       "rdfs:label": {

--- a/schema/Itinerary/v2.0/README.md
+++ b/schema/Itinerary/v2.0/README.md
@@ -25,8 +25,5 @@ A complete planned trip containing an ordered sequence of legs, including transf
 | `transferCount` | no | number | Number of transfers in the itinerary |
 | `departureTime` | no | string | Departure time of the first leg |
 | `arrivalTime` | no | string | Arrival time of the last leg |
-| `id` | no | string | Unique identifier for the contract |
-| `descriptor` | no | $ref: https://schema.beckn.io/core/v2.0/Descriptor/attributes.yaml#components/schemas/Descriptor | Human-readable description of the contract |
-| `items` | no | $ref: https://schema.beckn.io/ContractItem/v2.0/attributes.yaml#/components/schemas/ContractItem | Line items within the contract |
-| `fulfillments` | no | $ref: https://schema.beckn.io/Fulfillment/v2.1/attributes.yaml#/components/schemas/Fulfillment | Fulfillments associated with this contract |
-| `state` | no | $ref: https://schema.beckn.io/State/v2.0/attributes.yaml#/components/schemas/State | Current state of the contract |
+| `id` | no | string | Unique identifier for the itinerary |
+| `descriptor` | no | $ref: https://schema.beckn.io/core/v2.0/Descriptor/attributes.yaml#components/schemas/Descriptor | Human-readable description of the itinerary |

--- a/schema/Itinerary/v2.0/attributes.yaml
+++ b/schema/Itinerary/v2.0/attributes.yaml
@@ -44,18 +44,9 @@ components:
           type: string
           format: date-time
         id:
-          description: Unique identifier for the contract
+          description: Unique identifier for the itinerary
           type: string
         descriptor:
-          description: Human-readable description of the contract
+          description: Human-readable description of the itinerary
           $ref: https://schema.beckn.io/Descriptor/v2.0/attributes.yaml#/components/schemas/Descriptor
-        items:
-          description: Line items within the contract
-          $ref: https://schema.beckn.io/ContractItem/v2.0/attributes.yaml#/components/schemas/ContractItem
-        fulfillments:
-          description: Fulfillments associated with this contract
-          $ref: https://schema.beckn.io/Fulfillment/v2.1/attributes.yaml#/components/schemas/Fulfillment
-        state:
-          description: Current state of the contract
-          $ref: https://schema.beckn.io/State/v2.0/attributes.yaml#/components/schemas/State
       additionalProperties: false

--- a/schema/Itinerary/v2.0/context.jsonld
+++ b/schema/Itinerary/v2.0/context.jsonld
@@ -9,9 +9,6 @@
     "departureTime": "beckn:departureTime",
     "arrivalTime": "beckn:arrivalTime",
     "id": "beckn:id",
-    "descriptor": "beckn:descriptor",
-    "items": "beckn:items",
-    "fulfillments": "beckn:fulfillments",
-    "state": "beckn:state"
+    "descriptor": "beckn:descriptor"
   }
 }

--- a/schema/Itinerary/v2.0/schema.json
+++ b/schema/Itinerary/v2.0/schema.json
@@ -34,24 +34,12 @@
       "format": "date-time"
     },
     "id": {
-      "description": "Unique identifier for the contract",
+      "description": "Unique identifier for the itinerary",
       "type": "string"
     },
     "descriptor": {
-      "description": "Human-readable description of the contract",
+      "description": "Human-readable description of the itinerary",
       "$ref": "https://schema.beckn.io/Descriptor/v2.1/schema.json"
-    },
-    "items": {
-      "description": "Line items within the contract",
-      "$ref": "https://schema.beckn.io/ContractItem/v2.0/schema.json"
-    },
-    "fulfillments": {
-      "description": "Fulfillments associated with this contract",
-      "$ref": "https://schema.beckn.io/Fulfillment/v2.1/schema.json"
-    },
-    "state": {
-      "description": "Current state of the contract",
-      "$ref": "https://schema.beckn.io/State/v2.0/schema.json"
     }
   },
   "additionalProperties": false,

--- a/schema/Itinerary/v2.0/vocab.jsonld
+++ b/schema/Itinerary/v2.0/vocab.jsonld
@@ -163,7 +163,7 @@
         "@language": "en"
       },
       "rdfs:comment": {
-        "@value": "Unique identifier for the contract",
+        "@value": "Unique identifier for the itinerary",
         "@language": "en"
       },
       "rdfs:domain": {
@@ -184,7 +184,7 @@
         "@language": "en"
       },
       "rdfs:comment": {
-        "@value": "Human-readable description of the contract",
+        "@value": "Human-readable description of the itinerary",
         "@language": "en"
       },
       "rdfs:domain": {
@@ -192,60 +192,6 @@
       },
       "rdfs:range": {
         "@id": "https://schema.beckn.io/core/v2.0/#Descriptor"
-      }
-    },
-    {
-      "@id": "beckn:items",
-      "@type": "rdf:Property",
-      "rdfs:label": {
-        "@value": "items",
-        "@language": "en"
-      },
-      "rdfs:comment": {
-        "@value": "Line items within the contract",
-        "@language": "en"
-      },
-      "rdfs:domain": {
-        "@id": "beckn:Itinerary"
-      },
-      "rdfs:range": {
-        "@id": "https://schema.beckn.io/core/v2.0/#ContractItem"
-      }
-    },
-    {
-      "@id": "beckn:fulfillments",
-      "@type": "rdf:Property",
-      "rdfs:label": {
-        "@value": "fulfillments",
-        "@language": "en"
-      },
-      "rdfs:comment": {
-        "@value": "Fulfillments associated with this contract",
-        "@language": "en"
-      },
-      "rdfs:domain": {
-        "@id": "beckn:Itinerary"
-      },
-      "rdfs:range": {
-        "@id": "https://schema.beckn.io/core/v2.0/#Fulfillment"
-      }
-    },
-    {
-      "@id": "beckn:state",
-      "@type": "rdf:Property",
-      "rdfs:label": {
-        "@value": "state",
-        "@language": "en"
-      },
-      "rdfs:comment": {
-        "@value": "Current state of the contract",
-        "@language": "en"
-      },
-      "rdfs:domain": {
-        "@id": "beckn:Itinerary"
-      },
-      "rdfs:range": {
-        "@id": "https://schema.beckn.io/core/v2.0/#State"
       }
     }
   ]

--- a/schema/Journey/v2.0/README.md
+++ b/schema/Journey/v2.0/README.md
@@ -24,8 +24,5 @@ A complete travel itinerary from origin to destination, potentially comprising m
 | `departureTime` | no | string | Planned departure time |
 | `arrivalTime` | no | string | Planned arrival time |
 | `legs` | no | $ref: https://schema.beckn.io/Leg/v2.0/attributes.yaml#/components/schemas/Leg | Ordered list of legs comprising this journey |
-| `id` | no | string | Unique identifier for the contract |
-| `descriptor` | no | $ref: https://schema.beckn.io/core/v2.0/Descriptor/attributes.yaml#components/schemas/Descriptor | Human-readable description of the contract |
-| `items` | no | $ref: https://schema.beckn.io/ContractItem/v2.0/attributes.yaml#/components/schemas/ContractItem | Line items within the contract |
-| `fulfillments` | no | $ref: https://schema.beckn.io/Fulfillment/v2.1/attributes.yaml#/components/schemas/Fulfillment | Fulfillments associated with this contract |
-| `state` | no | $ref: https://schema.beckn.io/State/v2.0/attributes.yaml#/components/schemas/State | Current state of the contract |
+| `id` | no | string | Unique identifier for the journey |
+| `descriptor` | no | $ref: https://schema.beckn.io/core/v2.0/Descriptor/attributes.yaml#components/schemas/Descriptor | Human-readable description of the journey |

--- a/schema/Journey/v2.0/attributes.yaml
+++ b/schema/Journey/v2.0/attributes.yaml
@@ -40,18 +40,9 @@ components:
           description: Ordered list of legs comprising this journey
           $ref: https://schema.beckn.io/Leg/v2.0/attributes.yaml#/components/schemas/Leg
         id:
-          description: Unique identifier for the contract
+          description: Unique identifier for the journey
           type: string
         descriptor:
-          description: Human-readable description of the contract
+          description: Human-readable description of the journey
           $ref: https://schema.beckn.io/Descriptor/v2.0/attributes.yaml#/components/schemas/Descriptor
-        items:
-          description: Line items within the contract
-          $ref: https://schema.beckn.io/ContractItem/v2.0/attributes.yaml#/components/schemas/ContractItem
-        fulfillments:
-          description: Fulfillments associated with this contract
-          $ref: https://schema.beckn.io/Fulfillment/v2.1/attributes.yaml#/components/schemas/Fulfillment
-        state:
-          description: Current state of the contract
-          $ref: https://schema.beckn.io/State/v2.0/attributes.yaml#/components/schemas/State
       additionalProperties: false

--- a/schema/Journey/v2.0/context.jsonld
+++ b/schema/Journey/v2.0/context.jsonld
@@ -8,9 +8,6 @@
     "arrivalTime": "beckn:arrivalTime",
     "legs": "beckn:legs",
     "id": "beckn:id",
-    "descriptor": "beckn:descriptor",
-    "items": "beckn:items",
-    "fulfillments": "beckn:fulfillments",
-    "state": "beckn:state"
+    "descriptor": "beckn:descriptor"
   }
 }

--- a/schema/Journey/v2.0/schema.json
+++ b/schema/Journey/v2.0/schema.json
@@ -29,24 +29,12 @@
       "$ref": "https://schema.beckn.io/Leg/v2.0/schema.json"
     },
     "id": {
-      "description": "Unique identifier for the contract",
+      "description": "Unique identifier for the journey",
       "type": "string"
     },
     "descriptor": {
-      "description": "Human-readable description of the contract",
+      "description": "Human-readable description of the journey",
       "$ref": "https://schema.beckn.io/Descriptor/v2.1/schema.json"
-    },
-    "items": {
-      "description": "Line items within the contract",
-      "$ref": "https://schema.beckn.io/ContractItem/v2.0/schema.json"
-    },
-    "fulfillments": {
-      "description": "Fulfillments associated with this contract",
-      "$ref": "https://schema.beckn.io/Fulfillment/v2.1/schema.json"
-    },
-    "state": {
-      "description": "Current state of the contract",
-      "$ref": "https://schema.beckn.io/State/v2.0/schema.json"
     }
   },
   "additionalProperties": false,

--- a/schema/Journey/v2.0/vocab.jsonld
+++ b/schema/Journey/v2.0/vocab.jsonld
@@ -136,7 +136,7 @@
         "@language": "en"
       },
       "rdfs:comment": {
-        "@value": "Unique identifier for the contract",
+        "@value": "Unique identifier for the journey",
         "@language": "en"
       },
       "rdfs:domain": {
@@ -157,7 +157,7 @@
         "@language": "en"
       },
       "rdfs:comment": {
-        "@value": "Human-readable description of the contract",
+        "@value": "Human-readable description of the journey",
         "@language": "en"
       },
       "rdfs:domain": {
@@ -165,60 +165,6 @@
       },
       "rdfs:range": {
         "@id": "https://schema.beckn.io/core/v2.0/#Descriptor"
-      }
-    },
-    {
-      "@id": "beckn:items",
-      "@type": "rdf:Property",
-      "rdfs:label": {
-        "@value": "items",
-        "@language": "en"
-      },
-      "rdfs:comment": {
-        "@value": "Line items within the contract",
-        "@language": "en"
-      },
-      "rdfs:domain": {
-        "@id": "beckn:Journey"
-      },
-      "rdfs:range": {
-        "@id": "https://schema.beckn.io/core/v2.0/#ContractItem"
-      }
-    },
-    {
-      "@id": "beckn:fulfillments",
-      "@type": "rdf:Property",
-      "rdfs:label": {
-        "@value": "fulfillments",
-        "@language": "en"
-      },
-      "rdfs:comment": {
-        "@value": "Fulfillments associated with this contract",
-        "@language": "en"
-      },
-      "rdfs:domain": {
-        "@id": "beckn:Journey"
-      },
-      "rdfs:range": {
-        "@id": "https://schema.beckn.io/core/v2.0/#Fulfillment"
-      }
-    },
-    {
-      "@id": "beckn:state",
-      "@type": "rdf:Property",
-      "rdfs:label": {
-        "@value": "state",
-        "@language": "en"
-      },
-      "rdfs:comment": {
-        "@value": "Current state of the contract",
-        "@language": "en"
-      },
-      "rdfs:domain": {
-        "@id": "beckn:Journey"
-      },
-      "rdfs:range": {
-        "@id": "https://schema.beckn.io/core/v2.0/#State"
       }
     }
   ]

--- a/schema/Leg/v2.0/README.md
+++ b/schema/Leg/v2.0/README.md
@@ -30,7 +30,6 @@ A single uninterrupted segment of a journey made using one transport mode or ser
 | `id` | no | string | Unique identifier for the fulfillment |
 | `type` | no | string | Type of fulfillment (extensible term) |
 | `agent` | no | $ref: https://schema.beckn.io/FulfillmentAgent/v2.0/attributes.yaml#/components/schemas/FulfillmentAgent | The entity responsible for performing the fulfillment |
-| `state` | no | $ref: https://schema.beckn.io/State/v2.0/attributes.yaml#/components/schemas/State | Current state of the fulfillment |
 | `participants` | no | $ref: https://schema.beckn.io/Participant/v2.0/attributes.yaml#/components/schemas/Participant | Participants entitled to receive this fulfillment |
 | `stages` | no | $ref: https://schema.beckn.io/FulfillmentStage/v2.0/attributes.yaml#/components/schemas/FulfillmentStage | Stages in the fulfillment lifecycle |
 | `instructions` | no | $ref: https://schema.beckn.io/core/v2.0/Descriptor/attributes.yaml#components/schemas/Descriptor | Instructions for fulfillment |

--- a/schema/Leg/v2.0/attributes.yaml
+++ b/schema/Leg/v2.0/attributes.yaml
@@ -57,9 +57,6 @@ components:
         agent:
           description: The entity responsible for performing the fulfillment
           $ref: https://schema.beckn.io/FulfillmentAgent/v2.0/attributes.yaml#/components/schemas/FulfillmentAgent
-        state:
-          description: Current state of the fulfillment
-          $ref: https://schema.beckn.io/State/v2.0/attributes.yaml#/components/schemas/State
         participants:
           description: Participants entitled to receive this fulfillment
           $ref: https://schema.beckn.io/Participant/v2.0/attributes.yaml#/components/schemas/Participant

--- a/schema/Leg/v2.0/context.jsonld
+++ b/schema/Leg/v2.0/context.jsonld
@@ -13,7 +13,6 @@
     "id": "beckn:id",
     "type": "beckn:type",
     "agent": "beckn:agent",
-    "state": "beckn:state",
     "participants": "beckn:participants",
     "stages": "beckn:stages",
     "instructions": "beckn:instructions"

--- a/schema/Leg/v2.0/schema.json
+++ b/schema/Leg/v2.0/schema.json
@@ -52,10 +52,6 @@
       "description": "The entity responsible for performing the fulfillment",
       "$ref": "https://schema.beckn.io/FulfillmentAgent/v2.0/schema.json"
     },
-    "state": {
-      "description": "Current state of the fulfillment",
-      "$ref": "https://schema.beckn.io/State/v2.0/schema.json"
-    },
     "participants": {
       "description": "Participants entitled to receive this fulfillment",
       "$ref": "https://schema.beckn.io/Participant/v2.0/schema.json"

--- a/schema/Leg/v2.0/vocab.jsonld
+++ b/schema/Leg/v2.0/vocab.jsonld
@@ -270,24 +270,6 @@
       }
     },
     {
-      "@id": "beckn:state",
-      "@type": "rdf:Property",
-      "rdfs:label": {
-        "@value": "state",
-        "@language": "en"
-      },
-      "rdfs:comment": {
-        "@value": "Current state of the fulfillment",
-        "@language": "en"
-      },
-      "rdfs:domain": {
-        "@id": "beckn:Leg"
-      },
-      "rdfs:range": {
-        "@id": "https://schema.beckn.io/core/v2.0/#State"
-      }
-    },
-    {
       "@id": "beckn:participants",
       "@type": "rdf:Property",
       "rdfs:label": {

--- a/schema/Operator/v2.0/README.md
+++ b/schema/Operator/v2.0/README.md
@@ -28,6 +28,5 @@ An organization that provides and operates public transport or shared mobility s
 | `categories` | no | $ref: https://schema.beckn.io/CategoryCode/v2.1/attributes.yaml#/components/schemas/CategoryCode | Service categories offered by the provider |
 | `locations` | no | $ref: https://schema.beckn.io/Location/v2.0/attributes.yaml#/components/schemas/Location | Locations where the provider offers services |
 | `items` | no | $ref: https://schema.beckn.io/Item/v2.1/attributes.yaml#/components/schemas/Item | Items available for discovery from this provider |
-| `fulfillments` | no | $ref: https://schema.beckn.io/Fulfillment/v2.1/attributes.yaml#/components/schemas/Fulfillment | Fulfillment options offered by this provider |
 | `ratingsTotal` | no | number | Total number of ratings received |
 | `rating` | no | $ref: https://schema.beckn.io/Rating/v2.0/attributes.yaml#/components/schemas/Rating | Aggregate rating of the provider |

--- a/schema/Operator/v2.0/attributes.yaml
+++ b/schema/Operator/v2.0/attributes.yaml
@@ -50,9 +50,6 @@ components:
         items:
           description: Items available for discovery from this provider
           $ref: https://schema.beckn.io/Item/v2.1/attributes.yaml#/components/schemas/Item
-        fulfillments:
-          description: Fulfillment options offered by this provider
-          $ref: https://schema.beckn.io/Fulfillment/v2.1/attributes.yaml#/components/schemas/Fulfillment
         ratingsTotal:
           description: Total number of ratings received
           type: number

--- a/schema/Operator/v2.0/context.jsonld
+++ b/schema/Operator/v2.0/context.jsonld
@@ -11,7 +11,6 @@
     "categories": "beckn:categories",
     "locations": "beckn:locations",
     "items": "beckn:items",
-    "fulfillments": "beckn:fulfillments",
     "ratingsTotal": "beckn:ratingsTotal",
     "rating": "beckn:rating"
   }

--- a/schema/Operator/v2.0/schema.json
+++ b/schema/Operator/v2.0/schema.json
@@ -42,10 +42,6 @@
       "description": "Items available for discovery from this provider",
       "$ref": "https://schema.beckn.io/Item/v2.1/schema.json"
     },
-    "fulfillments": {
-      "description": "Fulfillment options offered by this provider",
-      "$ref": "https://schema.beckn.io/Fulfillment/v2.1/schema.json"
-    },
     "ratingsTotal": {
       "description": "Total number of ratings received",
       "type": "number"

--- a/schema/Operator/v2.0/vocab.jsonld
+++ b/schema/Operator/v2.0/vocab.jsonld
@@ -202,24 +202,6 @@
       }
     },
     {
-      "@id": "beckn:fulfillments",
-      "@type": "rdf:Property",
-      "rdfs:label": {
-        "@value": "fulfillments",
-        "@language": "en"
-      },
-      "rdfs:comment": {
-        "@value": "Fulfillment options offered by this provider",
-        "@language": "en"
-      },
-      "rdfs:domain": {
-        "@id": "beckn:Operator"
-      },
-      "rdfs:range": {
-        "@id": "https://schema.beckn.io/core/v2.0/#Fulfillment"
-      }
-    },
-    {
       "@id": "beckn:ratingsTotal",
       "@type": "rdf:Property",
       "rdfs:label": {

--- a/schema/PriceComponent/v2.2/README.md
+++ b/schema/PriceComponent/v2.2/README.md
@@ -1,4 +1,4 @@
-# PriceComponent — v2.1
+# PriceComponent — v2.2
 
 A single line item within a `PriceSpecification` breakup, such as a base charge, tax, delivery cost, discount, fee, or surcharge. Beyond the monetary amount, a `PriceComponent` MAY carry a JSON-LD `componentAttributes` bag that richly describes why the component applies, how it is calculated, and any governing terms — enabling a receiving node to render or act on the line (for example, highlight a surge charge or notify the user) without performing any price computation of its own.
 
@@ -15,7 +15,7 @@ A single line item within a `PriceSpecification` breakup, such as a base charge,
 
 | Property | Required | Type | Description |
 |---|---|---|---|
-| `type` | no | string (enum) | The nature of this price component: `UNIT`, `TAX`, `DELIVERY`, `DISCOUNT`, `FEE`, `SURCHARGE`, `DEPOSIT_REFUNDABLE`, `DEPOSIT`, `ADVANCE`, `TIP`, `CARRY_FORWARD`, `PENALTY`, `DONATION`, `TRANCHE`, `CASHBACK`, `SERVICE_FEE`, `PROCESSING_FEE`, `CONVENIENCE_FEE`, `REFUND`, `TOTAL`, `OTHER` |
+| `type` | no | string (enum) | The nature of this price component: `UNIT`, `TAX`, `DELIVERY`, `DISCOUNT`, `FEE`, `SURCHARGE`, `DEPOSIT_REFUNDABLE`, `DEPOSIT_NON_REFUNDABLE`, `ADVANCE`, `TIP`, `CARRY_FORWARD`, `PENALTY`, `DONATION`, `TRANCHE`, `CASHBACK`, `SERVICE_FEE`, `PROCESSING_FEE`, `CONVENIENCE_FEE`, `REFUND`, `TOTAL`, `OTHER` |
 | `value` | no | number | Monetary amount of this component, expressed in `currency` |
 | `currency` | no | string | ISO 4217 currency code for `value` |
 | `description` | no | string | Human-readable label for this component |

--- a/schema/PriceComponent/v2.2/README.md
+++ b/schema/PriceComponent/v2.2/README.md
@@ -1,0 +1,63 @@
+# PriceComponent — v2.1
+
+A single line item within a `PriceSpecification` breakup, such as a base charge, tax, delivery cost, discount, fee, or surcharge. Beyond the monetary amount, a `PriceComponent` MAY carry a JSON-LD `componentAttributes` bag that richly describes why the component applies, how it is calculated, and any governing terms — enabling a receiving node to render or act on the line (for example, highlight a surge charge or notify the user) without performing any price computation of its own.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| [https://schema.beckn.io/PriceComponent/v2.2/attributes.yaml](https://schema.beckn.io/PriceComponent/v2.2/attributes.yaml) | OpenAPI schema envelope (versioned path) |
+| [https://schema.beckn.io/PriceComponent/v2.2/schema.json](https://schema.beckn.io/PriceComponent/v2.2/schema.json) | JSON Schema document (versioned path) |
+| [https://schema.beckn.io/PriceComponent/v2.2/context.jsonld](https://schema.beckn.io/PriceComponent/v2.2/context.jsonld) | JSON-LD context (versioned path) |
+| [https://schema.beckn.io/PriceComponent/v2.2/vocab.jsonld](https://schema.beckn.io/PriceComponent/v2.2/vocab.jsonld) | RDF vocabulary (versioned path) |
+
+## Properties
+
+| Property | Required | Type | Description |
+|---|---|---|---|
+| `type` | no | string (enum) | The nature of this price component: `UNIT`, `TAX`, `DELIVERY`, `DISCOUNT`, `FEE`, `SURCHARGE`, `DEPOSIT_REFUNDABLE`, `DEPOSIT`, `ADVANCE`, `TIP`, `CARRY_FORWARD`, `PENALTY`, `DONATION`, `TRANCHE`, `CASHBACK`, `SERVICE_FEE`, `PROCESSING_FEE`, `CONVENIENCE_FEE`, `REFUND`, `TOTAL`, `OTHER` |
+| `value` | no | number | Monetary amount of this component, expressed in `currency` |
+| `currency` | no | string | ISO 4217 currency code for `value` |
+| `description` | no | string | Human-readable label for this component |
+| `componentAttributes` | no | $ref: https://schema.beckn.io/Attributes/v2.0/schema.json | JSON-LD aware container describing the rationale, calculation, and terms of this component. MUST include `@context` and `@type` |
+
+## Examples
+
+A surged base fare, with the SurgeMultiplier carried in `componentAttributes`:
+
+```json
+{
+  "type": "UNIT",
+  "value": 14.40,
+  "currency": "EUR",
+  "description": "(Base fare + distance) X 1.2x surge pricing",
+  "componentAttributes": {
+    "@context": "https://schema.beckn.io/SurgeMultiplier/2.0/context.jsonld",
+    "@type": "SurgeMultiplier",
+    "multiplierValue": 1.2,
+    "reason": "HIGH_DEMAND",
+    "validUntil": "2026-07-06T10:00:00Z",
+    "appliedTo": { "@type": "PriceSpecification", "currency": "EUR", "value": 12.00 }
+  }
+}
+```
+
+A refundable deposit, with its settlement terms carried in `componentAttributes`:
+
+```json
+{
+  "type": "DEPOSIT_REFUNDABLE",
+  "value": 150.00,
+  "currency": "EUR",
+  "description": "Refundable security deposit (hold; refunded after return of the vehicle undamaged)",
+  "componentAttributes": {
+    "@context": "https://schema.beckn.io/SettlementTerm/2.0/context.jsonld",
+    "@type": "SettlementTerm",
+    "amount": { "currency": "EUR", "value": 150.00 },
+    "paymentTrigger": "POST_FULFILLMENT",
+    "settlementStatus": "PENDING",
+    "payTo": { "vpa": "rider-refund-account@bank" },
+    "acceptedPaymentMethods": ["BANK_TRANSFER"]
+  }
+}
+```

--- a/schema/PriceComponent/v2.2/attributes.yaml
+++ b/schema/PriceComponent/v2.2/attributes.yaml
@@ -1,0 +1,103 @@
+openapi: 3.1.1
+info:
+  title: PriceComponent
+  version: 2.2.0
+  description: A single line item within a PriceSpecification breakup, optionally enriched with a JSON-LD componentAttributes bag describing its rationale, calculation, and terms.
+  license:
+    name: CC-BY-NC-SA 4.0 International
+  contact:
+    name: Beckn Labs
+    url: https://beckn.io
+components:
+  schemas:
+    PriceComponent:
+      x-iri: https://schema.beckn.io/PriceComponent/v2.2
+      title: PriceComponent
+      description: A single line item within a PriceSpecification breakup, such as a base charge, tax, delivery cost, discount, fee, or surcharge. Beyond the monetary amount, a PriceComponent MAY carry a JSON-LD componentAttributes bag that richly describes why the component applies, how it is calculated, and any governing terms. This lets a receiving node render or act on the line without performing any price computation of its own.
+      type: object
+      additionalProperties: false
+      properties:
+        type:
+          type: string
+          description: The nature of this price component.
+          enum:
+          - UNIT
+          - RENTAL
+          - USAGE
+          - OVERAGE
+          - TAX
+          - WITHHOLDING_TAX
+          - DELIVERY
+          - HANDLING_FEE
+          - PACKAGING_FEE
+          - INSTALLATION_FEE
+          - FUEL_SURCHARGE
+          - TOLL
+          - WAITING_CHARGE
+          - FEE
+          - SERVICE_FEE
+          - SERVICE_CHARGE
+          - PROCESSING_FEE
+          - CONVENIENCE_FEE
+          - PLATFORM_FEE
+          - BOOKING_FEE
+          - SETUP_FEE
+          - MEMBERSHIP_FEE
+          - SUBSCRIPTION_FEE
+          - COMMISSION
+          - FOREIGN_TRANSACTION_FEE
+          - MINIMUM_ORDER_FEE
+          - REGULATORY_FEE
+          - ENVIRONMENTAL_FEE
+          - SURCHARGE
+          - SURGE
+          - COVER_CHARGE
+          - PENALTY
+          - CANCELLATION_FEE
+          - LATE_FEE
+          - NO_SHOW_FEE
+          - DISCOUNT
+          - PROMOTION
+          - COUPON
+          - VOUCHER
+          - CASHBACK
+          - LOYALTY_REDEMPTION
+          - CREDIT
+          - REFUND
+          - DEPOSIT_REFUNDABLE
+          - DEPOSIT_NON_REFUNDABLE
+          - ADVANCE
+          - DOWN_PAYMENT
+          - PRINCIPAL
+          - INTEREST
+          - INSTALLMENT
+          - TRANCHE
+          - CARRY_FORWARD
+          - WALLET
+          - CHARGEBACK
+          - SETTLEMENT
+          - INSURANCE
+          - WARRANTY
+          - TIP
+          - DONATION
+          - ROUNDING
+          - ADJUSTMENT
+          - SUBTOTAL
+          - TOTAL
+          - OTHER
+        value:
+          type: number
+          description: Monetary amount of this component, expressed in currency.
+        currency:
+          type: string
+          description: ISO 4217 currency code for value.
+        description:
+          type: string
+          description: Human-readable label for this component.
+        componentAttributes:
+          description: JSON-LD aware container describing the rationale, calculation basis, and governing terms of this price component (for example a SurgeMultiplier, a FareLegRule with TariffZones, or a tax jurisdiction). MUST include @context and @type.
+          $ref: https://schema.beckn.io/Attributes/v2.0/attributes.yaml#/components/schemas/Attributes
+      x-jsonld:
+        '@id': beckn:PriceComponent
+      x-tags:
+      - common

--- a/schema/PriceComponent/v2.2/context.jsonld
+++ b/schema/PriceComponent/v2.2/context.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@protected": true,
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "beckn": "https://schema.beckn.io/LinkedData/v2.1/context.jsonld",
+    "PriceComponent": "beckn:PriceComponent",
+    "type": "beckn:type",
+    "value": "beckn:value",
+    "currency": "beckn:currency",
+    "description": "beckn:description",
+    "componentAttributes": "beckn:componentAttributes",
+    "x-jsonld": "beckn:x-jsonld",
+    "@type": "beckn:@type"
+  }
+}

--- a/schema/PriceComponent/v2.2/schema.json
+++ b/schema/PriceComponent/v2.2/schema.json
@@ -1,0 +1,103 @@
+{
+  "$id": "https://schema.beckn.io/PriceComponent/v2.2",
+  "x-iri": "https://schema.beckn.io/PriceComponent/v2.2",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "PriceComponent",
+  "description": "A single line item within a PriceSpecification breakup, such as a base charge, tax, delivery cost, discount, fee, or surcharge. Beyond the monetary amount, a PriceComponent MAY carry a JSON-LD `componentAttributes` bag that richly describes why the component applies, how it is calculated, and any governing terms. This lets a receiving node render or act on the line (for example, highlight a surge charge or notify the user) without performing any price computation of its own.",
+  "type": "object",
+  "properties": {
+    "type": {
+      "type": "string",
+      "description": "The nature of this price component.",
+      "enum": [
+        "UNIT",
+        "RENTAL",
+        "USAGE",
+        "OVERAGE",
+        "TAX",
+        "WITHHOLDING_TAX",
+        "DELIVERY",
+        "HANDLING_FEE",
+        "PACKAGING_FEE",
+        "INSTALLATION_FEE",
+        "FUEL_SURCHARGE",
+        "TOLL",
+        "WAITING_CHARGE",
+        "FEE",
+        "SERVICE_FEE",
+        "SERVICE_CHARGE",
+        "PROCESSING_FEE",
+        "CONVENIENCE_FEE",
+        "PLATFORM_FEE",
+        "BOOKING_FEE",
+        "SETUP_FEE",
+        "MEMBERSHIP_FEE",
+        "SUBSCRIPTION_FEE",
+        "COMMISSION",
+        "FOREIGN_TRANSACTION_FEE",
+        "MINIMUM_ORDER_FEE",
+        "REGULATORY_FEE",
+        "ENVIRONMENTAL_FEE",
+        "SURCHARGE",
+        "SURGE",
+        "COVER_CHARGE",
+        "PENALTY",
+        "CANCELLATION_FEE",
+        "LATE_FEE",
+        "NO_SHOW_FEE",
+        "DISCOUNT",
+        "PROMOTION",
+        "COUPON",
+        "VOUCHER",
+        "CASHBACK",
+        "LOYALTY_REDEMPTION",
+        "CREDIT",
+        "REFUND",
+        "DEPOSIT_REFUNDABLE",
+        "DEPOSIT_NON_REFUNDABLE",
+        "ADVANCE",
+        "DOWN_PAYMENT",
+        "PRINCIPAL",
+        "INTEREST",
+        "INSTALLMENT",
+        "TRANCHE",
+        "CARRY_FORWARD",
+        "WALLET",
+        "CHARGEBACK",
+        "SETTLEMENT",
+        "INSURANCE",
+        "WARRANTY",
+        "TIP",
+        "DONATION",
+        "ROUNDING",
+        "ADJUSTMENT",
+        "SUBTOTAL",
+        "TOTAL",
+        "OTHER"
+      ]
+    },
+    "value": {
+      "type": "number",
+      "description": "Monetary amount of this component, expressed in `currency`."
+    },
+    "currency": {
+      "type": "string",
+      "description": "ISO 4217 currency code for `value`."
+    },
+    "description": {
+      "type": "string",
+      "description": "Human-readable label for this component."
+    },
+    "componentAttributes": {
+      "description": "JSON-LD aware container describing the rationale, calculation basis, and governing terms of this price component (for example a SurgeMultiplier, a FareLegRule with TariffZones, or a tax jurisdiction). Follows the same composability rules as Attributes: MUST include @context and @type; any further properties are interpreted per the provided context.",
+      "$ref": "https://schema.beckn.io/Attributes/v2.0/schema.json"
+    }
+  },
+  "additionalProperties": false,
+  "x-jsonld": {
+    "@id": "beckn:PriceComponent"
+  },
+  "x-tags": [
+    "common"
+  ]
+}

--- a/schema/PriceComponent/v2.2/vocab.jsonld
+++ b/schema/PriceComponent/v2.2/vocab.jsonld
@@ -1,0 +1,55 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "beckn": "https://schema.beckn.io/LinkedData/v2.1/context.jsonld",
+    "owl": "http://www.w3.org/2002/07/owl#",
+    "schema": "https://schema.org/version/latest/schemaorg-current-https.jsonld",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "PriceComponent": "beckn:PriceComponent",
+    "type": "beckn:type",
+    "value": "beckn:value",
+    "currency": "beckn:currency",
+    "description": "beckn:description",
+    "componentAttributes": "beckn:componentAttributes"
+  },
+  "@graph": [
+    {
+      "@id": "beckn:PriceComponent",
+      "@type": "rdfs:Class",
+      "rdfs:label": "Price Component",
+      "rdfs:comment": "A single line item within a PriceSpecification breakup (base charge, tax, delivery, discount, fee, or surcharge), optionally enriched with a JSON-LD componentAttributes bag describing its rationale, calculation, and terms."
+    },
+    {
+      "@id": "beckn:type",
+      "@type": "rdf:Property",
+      "rdfs:label": "type",
+      "rdfs:comment": "The nature of this price component (UNIT, TAX, DELIVERY, DISCOUNT, FEE, SURCHARGE)."
+    },
+    {
+      "@id": "beckn:value",
+      "@type": "rdf:Property",
+      "rdfs:label": "value",
+      "rdfs:comment": "Monetary amount of this component, expressed in currency."
+    },
+    {
+      "@id": "beckn:currency",
+      "@type": "rdf:Property",
+      "rdfs:label": "currency",
+      "rdfs:comment": "ISO 4217 currency code for value."
+    },
+    {
+      "@id": "beckn:description",
+      "@type": "rdf:Property",
+      "rdfs:label": "description",
+      "rdfs:comment": "Human-readable label for this component."
+    },
+    {
+      "@id": "beckn:componentAttributes",
+      "@type": "rdf:Property",
+      "rdfs:label": "component Attributes",
+      "rdfs:comment": "JSON-LD aware container describing the rationale, calculation basis, and governing terms of this price component."
+    }
+  ]
+}

--- a/schema/PriceSpecification/v2.2/README.md
+++ b/schema/PriceSpecification/v2.2/README.md
@@ -1,4 +1,4 @@
-# PriceSpecification — v2.1
+# PriceSpecification — v2.2
 
 Schema definition for PriceSpecification in the Beckn Protocol v2.0.1
 

--- a/schema/PriceSpecification/v2.2/README.md
+++ b/schema/PriceSpecification/v2.2/README.md
@@ -1,0 +1,25 @@
+# PriceSpecification — v2.1
+
+Schema definition for PriceSpecification in the Beckn Protocol v2.0.1
+
+## Files
+
+| File | Purpose |
+|---|---|
+| [https://schema.beckn.io/PriceSpecification/attributes.yaml](https://schema.beckn.io/PriceSpecification/attributes.yaml) | OpenAPI schema envelope (latest path) |
+| [https://schema.beckn.io/PriceSpecification/v2.2/attributes.yaml](https://schema.beckn.io/PriceSpecification/v2.2/attributes.yaml) | OpenAPI schema envelope (versioned path) |
+| [https://schema.beckn.io/PriceSpecification/attributes.jsonschema.yaml](https://schema.beckn.io/PriceSpecification/attributes.jsonschema.yaml) | JSON Schema document (latest path) |
+| [https://schema.beckn.io/PriceSpecification/v2.2/attributes.jsonschema.yaml](https://schema.beckn.io/PriceSpecification/v2.2/attributes.jsonschema.yaml) | JSON Schema document (versioned path) |
+| [https://schema.beckn.io/PriceSpecification/context.jsonld](https://schema.beckn.io/PriceSpecification/context.jsonld) | JSON-LD context (latest path) |
+| [https://schema.beckn.io/PriceSpecification/v2.2/context.jsonld](https://schema.beckn.io/PriceSpecification/v2.2/context.jsonld) | JSON-LD context (versioned path) |
+| [https://schema.beckn.io/PriceSpecification/vocab.jsonld](https://schema.beckn.io/PriceSpecification/vocab.jsonld) | RDF vocabulary (latest path) |
+| [https://schema.beckn.io/PriceSpecification/v2.2/vocab.jsonld](https://schema.beckn.io/PriceSpecification/v2.2/vocab.jsonld) | RDF vocabulary (versioned path) |
+
+## Properties
+
+| Property | Required | Type | Description |
+|---|---|---|---|
+| `currency` | no | string | ISO 4217 code |
+| `value` | no | number | Total value for this price specification |
+| `applicableQuantity` | no | $ref: https://schema.beckn.io/Quantity/v2.0/attributes.yaml#/components/schemas/Quantity | - |
+| `components` | no | array | Optional components (tax, shipping, discount, fee, surcharge) |

--- a/schema/PriceSpecification/v2.2/attributes.yaml
+++ b/schema/PriceSpecification/v2.2/attributes.yaml
@@ -1,0 +1,38 @@
+openapi: 3.1.1
+info:
+  title: PriceSpecification
+  version: 2.2.0
+  description: Schema definition for PriceSpecification in the Beckn Protocol v2.0.1
+  license:
+    name: CC-BY-NC-SA 4.0 International
+  contact:
+    name: Beckn Labs
+    url: https://beckn.io
+components:
+  schemas:
+    PriceSpecification:
+      x-iri: https://schema.beckn.io/PriceSpecification/v2.2
+      description: Schema definition for PriceSpecification in the Beckn Protocol v2.0.1
+      title: PriceSpecification
+      type: object
+      additionalProperties: true
+      properties:
+        currency:
+          type: string
+          description: ISO 4217 code
+        value:
+          type: number
+          description: Total value for this price specification
+        applicableQuantity:
+          $ref: https://schema.beckn.io/Quantity/v2.0/attributes.yaml#/components/schemas/Quantity
+          x-jsonld:
+            '@id': schema:eligibleQuantity
+        components:
+          type: array
+          description: Optional itemised breakup of this price (base charge, tax, delivery, discount, fee, surcharge). Each element is a PriceComponent, which may carry a JSON-LD componentAttributes bag describing the rationale, calculation, and terms of the line.
+          items:
+            $ref: https://schema.beckn.io/PriceComponent/v2.2/attributes.yaml#/components/schemas/PriceComponent
+      x-jsonld:
+        '@id': schema:PriceSpecification
+      x-tags:
+      - common

--- a/schema/PriceSpecification/v2.2/context.jsonld
+++ b/schema/PriceSpecification/v2.2/context.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@protected": true,
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "beckn": "https://schema.beckn.io/LinkedData/v2.1/context.jsonld",
+    "PriceSpecification": "beckn:PriceSpecification",
+    "currency": "beckn:currency",
+    "value": "beckn:value",
+    "applicableQuantity": "beckn:applicableQuantity",
+    "components": "beckn:components",
+    "componentAttributes": "beckn:componentAttributes",
+    "x-jsonld": "beckn:x-jsonld",
+    "description": "beckn:description",
+    "type": "beckn:type"
+  }
+}

--- a/schema/PriceSpecification/v2.2/schema.json
+++ b/schema/PriceSpecification/v2.2/schema.json
@@ -1,0 +1,38 @@
+{
+  "$id": "https://schema.beckn.io/PriceSpecification/v2.2",
+  "x-iri": "https://schema.beckn.io/PriceSpecification/v2.2",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Schema definition for PriceSpecification in the Beckn Protocol v2.0.1",
+  "title": "PriceSpecification",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "currency": {
+      "type": "string",
+      "description": "ISO 4217 code"
+    },
+    "value": {
+      "type": "number",
+      "description": "Total value for this price specification"
+    },
+    "applicableQuantity": {
+      "$ref": "https://schema.beckn.io/Quantity/v2.0/schema.json",
+      "x-jsonld": {
+        "@id": "schema:eligibleQuantity"
+      }
+    },
+    "components": {
+      "type": "array",
+      "description": "Optional itemised breakup of this price (base charge, tax, delivery, discount, fee, surcharge). Each element is a PriceComponent, which may carry a JSON-LD componentAttributes bag describing the rationale, calculation, and terms of the line.",
+      "items": {
+        "$ref": "https://schema.beckn.io/PriceComponent/v2.2/schema.json"
+      }
+    }
+  },
+  "x-jsonld": {
+    "@id": "schema:PriceSpecification"
+  },
+  "x-tags": [
+    "common"
+  ]
+}

--- a/schema/PriceSpecification/v2.2/vocab.jsonld
+++ b/schema/PriceSpecification/v2.2/vocab.jsonld
@@ -1,0 +1,57 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "beckn": "https://schema.beckn.io/LinkedData/v2.1/context.jsonld",
+    "owl": "http://www.w3.org/2002/07/owl#",
+    "schema": "https://schema.org/version/latest/schemaorg-current-https.jsonld",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "PriceSpecification": "beckn:PriceSpecification",
+    "applicableQuantity": "beckn:applicableQuantity",
+    "components": "beckn:components",
+    "componentAttributes": "beckn:componentAttributes",
+    "currency": "beckn:currency",
+    "description": "beckn:description",
+    "type": "beckn:type",
+    "value": "beckn:value"
+  },
+  "@graph": [
+    {
+      "@id": "beckn:PriceSpecification",
+      "@type": "rdfs:Class",
+      "rdfs:label": "Price Specification",
+      "rdfs:comment": "Schema definition for PriceSpecification in the Beckn Protocol v2.0.1"
+    },
+    {
+      "@id": "beckn:currency",
+      "@type": "rdf:Property",
+      "rdfs:label": "currency",
+      "rdfs:comment": "ISO 4217 code"
+    },
+    {
+      "@id": "beckn:value",
+      "@type": "rdf:Property",
+      "rdfs:label": "value",
+      "rdfs:comment": "Total value for this price specification"
+    },
+    {
+      "@id": "beckn:applicableQuantity",
+      "@type": "rdf:Property",
+      "rdfs:label": "applicable Quantity",
+      "rdfs:comment": "TODO: Description Needed - applicableQuantity"
+    },
+    {
+      "@id": "beckn:components",
+      "@type": "rdf:Property",
+      "rdfs:label": "components",
+      "rdfs:comment": "Optional components (tax, shipping, discount, fee, surcharge)"
+    },
+    {
+      "@id": "beckn:x-jsonld",
+      "@type": "rdf:Property",
+      "rdfs:label": "x-jsonld",
+      "rdfs:comment": "TODO: Description Needed - x-jsonld"
+    }
+  ]
+}

--- a/schema/RideOption/v2.0/README.md
+++ b/schema/RideOption/v2.0/README.md
@@ -23,7 +23,7 @@ A specific ride-hailing vehicle category and pricing option presented to a passe
 | `estimatedArrival` | no | string | Estimated vehicle arrival time at the pickup point |
 | `estimatedDuration` | no | string | Estimated trip duration |
 | `estimatedDistance` | no | number | Estimated trip distance in kilometres |
-| `pricingModel` | no | $ref: https://schema.beckn.io/PricingModel/v2.0/attributes.yaml#/components/schemas/PricingModel | Pricing model applicable to this ride option |
+| `pricingModel` | no | $ref: https://schema.beckn.io/SystemPricingPlan/v2.0/attributes.yaml#/components/schemas/SystemPricingPlan | Pricing model applicable to this ride option |
 | `id` | no | string | Unique identifier for the offer |
 | `descriptor` | no | $ref: https://schema.beckn.io/core/v2.0/Descriptor/attributes.yaml#components/schemas/Descriptor | Human-readable description of the offer |
 | `price` | no | $ref: https://schema.beckn.io/PriceSpecification/v2.1/attributes.yaml#/components/schemas/PriceSpecification | Price specification for this offer |

--- a/schema/RideOption/v2.0/attributes.yaml
+++ b/schema/RideOption/v2.0/attributes.yaml
@@ -37,7 +37,7 @@ components:
           type: number
         pricingModel:
           description: Pricing model applicable to this ride option
-          $ref: https://schema.beckn.io/PricingModel/v2.0/attributes.yaml#/components/schemas/PricingModel
+          $ref: https://schema.beckn.io/SystemPricingPlan/v2.0/attributes.yaml#/components/schemas/SystemPricingPlan
         id:
           description: Unique identifier for the offer
           type: string

--- a/schema/RideOption/v2.0/schema.json
+++ b/schema/RideOption/v2.0/schema.json
@@ -26,7 +26,7 @@
     },
     "pricingModel": {
       "description": "Pricing model applicable to this ride option",
-      "$ref": "https://schema.beckn.io/PricingModel/v2.0/schema.json"
+      "$ref": "https://schema.beckn.io/SystemPricingPlan/v2.0/schema.json"
     },
     "id": {
       "description": "Unique identifier for the offer",

--- a/schema/RideOption/v2.0/vocab.jsonld
+++ b/schema/RideOption/v2.0/vocab.jsonld
@@ -22,7 +22,7 @@
       },
       "rdfs:seeAlso": [
         {
-          "@id": "beckn:PricingModel"
+          "@id": "beckn:SystemPricingPlan"
         },
         {
           "@id": "beckn:VehicleCategory"
@@ -128,10 +128,10 @@
         "@id": "beckn:RideOption"
       },
       "rdfs:range": {
-        "@id": "beckn:PricingModel"
+        "@id": "beckn:SystemPricingPlan"
       },
       "rdfs:seeAlso": {
-        "@id": "../PricingModel/v2.0/vocab.jsonld#beckn:PricingModel"
+        "@id": "../SystemPricingPlan/v2.0/vocab.jsonld#beckn:SystemPricingPlan"
       }
     },
     {

--- a/schema/Trip/v2.0/README.md
+++ b/schema/Trip/v2.0/README.md
@@ -27,8 +27,5 @@ A confirmed and booked journey from an origin to a destination, representing a c
 | `distance` | no | number | Total distance of the trip in kilometres |
 | `driverRef` | no | $ref: https://schema.beckn.io/Driver/v2.0/attributes.yaml#/components/schemas/Driver | Reference to the driver for this trip |
 | `vehicleRef` | no | $ref: https://schema.beckn.io/Vehicle/v2.0/attributes.yaml#/components/schemas/Vehicle | Reference to the vehicle for this trip |
-| `id` | no | string | Unique identifier for the contract |
-| `descriptor` | no | $ref: https://schema.beckn.io/core/v2.0/Descriptor/attributes.yaml#components/schemas/Descriptor | Human-readable description of the contract |
-| `items` | no | $ref: https://schema.beckn.io/ContractItem/v2.0/attributes.yaml#/components/schemas/ContractItem | Line items within the contract |
-| `fulfillments` | no | $ref: https://schema.beckn.io/Fulfillment/v2.1/attributes.yaml#/components/schemas/Fulfillment | Fulfillments associated with this contract |
-| `state` | no | $ref: https://schema.beckn.io/State/v2.0/attributes.yaml#/components/schemas/State | Current state of the contract |
+| `id` | no | string | Unique identifier for the trip |
+| `descriptor` | no | $ref: https://schema.beckn.io/core/v2.0/Descriptor/attributes.yaml#components/schemas/Descriptor | Human-readable description of the trip |

--- a/schema/Trip/v2.0/attributes.yaml
+++ b/schema/Trip/v2.0/attributes.yaml
@@ -48,18 +48,9 @@ components:
           description: Reference to the vehicle for this trip
           $ref: https://schema.beckn.io/Vehicle/v2.0/attributes.yaml#/components/schemas/Vehicle
         id:
-          description: Unique identifier for the contract
+          description: Unique identifier for the trip
           type: string
         descriptor:
-          description: Human-readable description of the contract
+          description: Human-readable description of the trip
           $ref: https://schema.beckn.io/Descriptor/v2.0/attributes.yaml#/components/schemas/Descriptor
-        items:
-          description: Line items within the contract
-          $ref: https://schema.beckn.io/ContractItem/v2.0/attributes.yaml#/components/schemas/ContractItem
-        fulfillments:
-          description: Fulfillments associated with this contract
-          $ref: https://schema.beckn.io/Fulfillment/v2.1/attributes.yaml#/components/schemas/Fulfillment
-        state:
-          description: Current state of the contract
-          $ref: https://schema.beckn.io/State/v2.0/attributes.yaml#/components/schemas/State
       additionalProperties: false

--- a/schema/Trip/v2.0/context.jsonld
+++ b/schema/Trip/v2.0/context.jsonld
@@ -11,9 +11,6 @@
     "driverRef": "beckn:driverRef",
     "vehicleRef": "beckn:vehicleRef",
     "id": "beckn:id",
-    "descriptor": "beckn:descriptor",
-    "items": "beckn:items",
-    "fulfillments": "beckn:fulfillments",
-    "state": "beckn:state"
+    "descriptor": "beckn:descriptor"
   }
 }

--- a/schema/Trip/v2.0/schema.json
+++ b/schema/Trip/v2.0/schema.json
@@ -41,24 +41,12 @@
       "$ref": "https://schema.beckn.io/Vehicle/v2.0/schema.json"
     },
     "id": {
-      "description": "Unique identifier for the contract",
+      "description": "Unique identifier for the trip",
       "type": "string"
     },
     "descriptor": {
-      "description": "Human-readable description of the contract",
+      "description": "Human-readable description of the trip",
       "$ref": "https://schema.beckn.io/Descriptor/v2.1/schema.json"
-    },
-    "items": {
-      "description": "Line items within the contract",
-      "$ref": "https://schema.beckn.io/ContractItem/v2.0/schema.json"
-    },
-    "fulfillments": {
-      "description": "Fulfillments associated with this contract",
-      "$ref": "https://schema.beckn.io/Fulfillment/v2.1/schema.json"
-    },
-    "state": {
-      "description": "Current state of the contract",
-      "$ref": "https://schema.beckn.io/State/v2.0/schema.json"
     }
   },
   "additionalProperties": false,

--- a/schema/Trip/v2.0/vocab.jsonld
+++ b/schema/Trip/v2.0/vocab.jsonld
@@ -199,7 +199,7 @@
         "@language": "en"
       },
       "rdfs:comment": {
-        "@value": "Unique identifier for the contract",
+        "@value": "Unique identifier for the trip",
         "@language": "en"
       },
       "rdfs:domain": {
@@ -220,7 +220,7 @@
         "@language": "en"
       },
       "rdfs:comment": {
-        "@value": "Human-readable description of the contract",
+        "@value": "Human-readable description of the trip",
         "@language": "en"
       },
       "rdfs:domain": {
@@ -228,60 +228,6 @@
       },
       "rdfs:range": {
         "@id": "https://schema.beckn.io/core/v2.0/#Descriptor"
-      }
-    },
-    {
-      "@id": "beckn:items",
-      "@type": "rdf:Property",
-      "rdfs:label": {
-        "@value": "items",
-        "@language": "en"
-      },
-      "rdfs:comment": {
-        "@value": "Line items within the contract",
-        "@language": "en"
-      },
-      "rdfs:domain": {
-        "@id": "beckn:Trip"
-      },
-      "rdfs:range": {
-        "@id": "https://schema.beckn.io/core/v2.0/#ContractItem"
-      }
-    },
-    {
-      "@id": "beckn:fulfillments",
-      "@type": "rdf:Property",
-      "rdfs:label": {
-        "@value": "fulfillments",
-        "@language": "en"
-      },
-      "rdfs:comment": {
-        "@value": "Fulfillments associated with this contract",
-        "@language": "en"
-      },
-      "rdfs:domain": {
-        "@id": "beckn:Trip"
-      },
-      "rdfs:range": {
-        "@id": "https://schema.beckn.io/core/v2.0/#Fulfillment"
-      }
-    },
-    {
-      "@id": "beckn:state",
-      "@type": "rdf:Property",
-      "rdfs:label": {
-        "@value": "state",
-        "@language": "en"
-      },
-      "rdfs:comment": {
-        "@value": "Current state of the contract",
-        "@language": "en"
-      },
-      "rdfs:domain": {
-        "@id": "beckn:Trip"
-      },
-      "rdfs:range": {
-        "@id": "https://schema.beckn.io/core/v2.0/#State"
       }
     }
   ]

--- a/schema/TripUpdate/v2.0/README.md
+++ b/schema/TripUpdate/v2.0/README.md
@@ -25,8 +25,5 @@ A multi-dimensional update to an in-progress or upcoming mobility trip, covering
 | `trackingEndpoint` | no | $ref: https://schema.beckn.io/Tracking/v2.1/attributes.yaml#/components/schemas/Tracking | Real-time tracking endpoint including URL, protocol, and data schema reference |
 | `driverRef` | no | $ref: https://schema.beckn.io/Driver/v2.0/attributes.yaml#/components/schemas/Driver | Reference to the current driver if changed from the originally assigned driver |
 | `updatedAt` | no | string | Timestamp when this trip update was issued |
-| `id` | no | string | Unique identifier for the contract |
-| `descriptor` | no | $ref: https://schema.beckn.io/core/v2.0/Descriptor/attributes.yaml#components/schemas/Descriptor | Human-readable description of the contract |
-| `items` | no | $ref: https://schema.beckn.io/ContractItem/v2.0/attributes.yaml#/components/schemas/ContractItem | Line items within the contract |
-| `fulfillments` | no | $ref: https://schema.beckn.io/Fulfillment/v2.1/attributes.yaml#/components/schemas/Fulfillment | Fulfillments associated with this contract |
-| `state` | no | $ref: https://schema.beckn.io/State/v2.0/attributes.yaml#/components/schemas/State | Current state of the contract |
+| `id` | no | string | Unique identifier for the trip update |
+| `descriptor` | no | $ref: https://schema.beckn.io/core/v2.0/Descriptor/attributes.yaml#components/schemas/Descriptor | Human-readable description of the trip update |

--- a/schema/TripUpdate/v2.0/attributes.yaml
+++ b/schema/TripUpdate/v2.0/attributes.yaml
@@ -47,18 +47,9 @@ components:
           type: string
           format: date-time
         id:
-          description: Unique identifier for the contract
+          description: Unique identifier for the trip update
           type: string
         descriptor:
-          description: Human-readable description of the contract
+          description: Human-readable description of the trip update
           $ref: https://schema.beckn.io/Descriptor/v2.0/attributes.yaml#/components/schemas/Descriptor
-        items:
-          description: Line items within the contract
-          $ref: https://schema.beckn.io/ContractItem/v2.0/attributes.yaml#/components/schemas/ContractItem
-        fulfillments:
-          description: Fulfillments associated with this contract
-          $ref: https://schema.beckn.io/Fulfillment/v2.1/attributes.yaml#/components/schemas/Fulfillment
-        state:
-          description: Current state of the contract
-          $ref: https://schema.beckn.io/State/v2.0/attributes.yaml#/components/schemas/State
       additionalProperties: false

--- a/schema/TripUpdate/v2.0/context.jsonld
+++ b/schema/TripUpdate/v2.0/context.jsonld
@@ -9,9 +9,6 @@
     "driverRef": "beckn:driverRef",
     "updatedAt": "beckn:updatedAt",
     "id": "beckn:id",
-    "descriptor": "beckn:descriptor",
-    "items": "beckn:items",
-    "fulfillments": "beckn:fulfillments",
-    "state": "beckn:state"
+    "descriptor": "beckn:descriptor"
   }
 }

--- a/schema/TripUpdate/v2.0/schema.json
+++ b/schema/TripUpdate/v2.0/schema.json
@@ -32,24 +32,12 @@
       "format": "date-time"
     },
     "id": {
-      "description": "Unique identifier for the contract",
+      "description": "Unique identifier for the trip update",
       "type": "string"
     },
     "descriptor": {
-      "description": "Human-readable description of the contract",
+      "description": "Human-readable description of the trip update",
       "$ref": "https://schema.beckn.io/Descriptor/v2.1/schema.json"
-    },
-    "items": {
-      "description": "Line items within the contract",
-      "$ref": "https://schema.beckn.io/ContractItem/v2.0/schema.json"
-    },
-    "fulfillments": {
-      "description": "Fulfillments associated with this contract",
-      "$ref": "https://schema.beckn.io/Fulfillment/v2.1/schema.json"
-    },
-    "state": {
-      "description": "Current state of the contract",
-      "$ref": "https://schema.beckn.io/State/v2.0/schema.json"
     }
   },
   "additionalProperties": false,

--- a/schema/TripUpdate/v2.0/vocab.jsonld
+++ b/schema/TripUpdate/v2.0/vocab.jsonld
@@ -146,7 +146,7 @@
         "@language": "en"
       },
       "rdfs:comment": {
-        "@value": "Unique identifier for the contract",
+        "@value": "Unique identifier for the trip update",
         "@language": "en"
       },
       "rdfs:domain": {
@@ -167,7 +167,7 @@
         "@language": "en"
       },
       "rdfs:comment": {
-        "@value": "Human-readable description of the contract",
+        "@value": "Human-readable description of the trip update",
         "@language": "en"
       },
       "rdfs:domain": {
@@ -175,60 +175,6 @@
       },
       "rdfs:range": {
         "@id": "https://schema.beckn.io/core/v2.0/#Descriptor"
-      }
-    },
-    {
-      "@id": "beckn:items",
-      "@type": "rdf:Property",
-      "rdfs:label": {
-        "@value": "items",
-        "@language": "en"
-      },
-      "rdfs:comment": {
-        "@value": "Line items within the contract",
-        "@language": "en"
-      },
-      "rdfs:domain": {
-        "@id": "beckn:TripUpdate"
-      },
-      "rdfs:range": {
-        "@id": "https://schema.beckn.io/core/v2.0/#ContractItem"
-      }
-    },
-    {
-      "@id": "beckn:fulfillments",
-      "@type": "rdf:Property",
-      "rdfs:label": {
-        "@value": "fulfillments",
-        "@language": "en"
-      },
-      "rdfs:comment": {
-        "@value": "Fulfillments associated with this contract",
-        "@language": "en"
-      },
-      "rdfs:domain": {
-        "@id": "beckn:TripUpdate"
-      },
-      "rdfs:range": {
-        "@id": "https://schema.beckn.io/core/v2.0/#Fulfillment"
-      }
-    },
-    {
-      "@id": "beckn:state",
-      "@type": "rdf:Property",
-      "rdfs:label": {
-        "@value": "state",
-        "@language": "en"
-      },
-      "rdfs:comment": {
-        "@value": "Current state of the contract",
-        "@language": "en"
-      },
-      "rdfs:domain": {
-        "@id": "beckn:TripUpdate"
-      },
-      "rdfs:range": {
-        "@id": "https://schema.beckn.io/core/v2.0/#State"
       }
     }
   ]

--- a/schema/VehicleJourney/v2.0/README.md
+++ b/schema/VehicleJourney/v2.0/README.md
@@ -29,7 +29,6 @@ A specific operational instance of a vehicle traveling a defined route at a sche
 | `type` | no | string | Type of fulfillment (extensible term) |
 | `agent` | no | $ref: https://schema.beckn.io/FulfillmentAgent/v2.0/attributes.yaml#/components/schemas/FulfillmentAgent | The entity responsible for performing the fulfillment |
 | `mode` | no | $ref: https://schema.beckn.io/FulfillmentMode/v2.0/attributes.yaml#/components/schemas/FulfillmentMode | Mode of fulfillment |
-| `state` | no | $ref: https://schema.beckn.io/State/v2.0/attributes.yaml#/components/schemas/State | Current state of the fulfillment |
 | `participants` | no | $ref: https://schema.beckn.io/Participant/v2.0/attributes.yaml#/components/schemas/Participant | Participants entitled to receive this fulfillment |
 | `stages` | no | $ref: https://schema.beckn.io/FulfillmentStage/v2.0/attributes.yaml#/components/schemas/FulfillmentStage | Stages in the fulfillment lifecycle |
 | `instructions` | no | $ref: https://schema.beckn.io/core/v2.0/Descriptor/attributes.yaml#components/schemas/Descriptor | Instructions for fulfillment |

--- a/schema/VehicleJourney/v2.0/attributes.yaml
+++ b/schema/VehicleJourney/v2.0/attributes.yaml
@@ -52,9 +52,6 @@ components:
         mode:
           description: Mode of fulfillment
           $ref: https://schema.beckn.io/FulfillmentMode/v2.0/attributes.yaml#/components/schemas/FulfillmentMode
-        state:
-          description: Current state of the fulfillment
-          $ref: https://schema.beckn.io/State/v2.0/attributes.yaml#/components/schemas/State
         participants:
           description: Participants entitled to receive this fulfillment
           $ref: https://schema.beckn.io/Participant/v2.0/attributes.yaml#/components/schemas/Participant

--- a/schema/VehicleJourney/v2.0/context.jsonld
+++ b/schema/VehicleJourney/v2.0/context.jsonld
@@ -12,7 +12,6 @@
     "type": "beckn:type",
     "agent": "beckn:agent",
     "mode": "beckn:mode",
-    "state": "beckn:state",
     "participants": "beckn:participants",
     "stages": "beckn:stages",
     "instructions": "beckn:instructions"

--- a/schema/VehicleJourney/v2.0/schema.json
+++ b/schema/VehicleJourney/v2.0/schema.json
@@ -46,10 +46,6 @@
       "description": "Mode of fulfillment",
       "$ref": "https://schema.beckn.io/FulfillmentMode/v2.0/schema.json"
     },
-    "state": {
-      "description": "Current state of the fulfillment",
-      "$ref": "https://schema.beckn.io/State/v2.0/schema.json"
-    },
     "participants": {
       "description": "Participants entitled to receive this fulfillment",
       "$ref": "https://schema.beckn.io/Participant/v2.0/schema.json"

--- a/schema/VehicleJourney/v2.0/vocab.jsonld
+++ b/schema/VehicleJourney/v2.0/vocab.jsonld
@@ -243,24 +243,6 @@
       }
     },
     {
-      "@id": "beckn:state",
-      "@type": "rdf:Property",
-      "rdfs:label": {
-        "@value": "state",
-        "@language": "en"
-      },
-      "rdfs:comment": {
-        "@value": "Current state of the fulfillment",
-        "@language": "en"
-      },
-      "rdfs:domain": {
-        "@id": "beckn:VehicleJourney"
-      },
-      "rdfs:range": {
-        "@id": "https://schema.beckn.io/core/v2.0/#State"
-      }
-    },
-    {
       "@id": "beckn:participants",
       "@type": "rdf:Property",
       "rdfs:label": {


### PR DESCRIPTION
## Summary
Three related schema updates, all in `schema/`:

### 1. `PriceComponent/v2.2` + `PriceSpecification/v2.2` (new)
- `PriceSpecification/v2.2` breaks the price breakup into typed **`PriceComponent`** line items. Each `PriceComponent` carries `type` (large enum), `value`, `currency`, `description`, and an optional JSON-LD **`componentAttributes`** bag describing the line's rationale / calculation / governing terms (e.g. a `SurgeMultiplier`, a `FareLegRule`+`TariffZone`s, a `SystemPricingPlan` rate, or a `SettlementTerm` for a refundable deposit).
- `PriceComponent` is referenced **only** by `PriceSpecification/v2.2`.
- `PriceSpecification/v2.1` is **unchanged** (left as originally published, with inline components).

### 2. `RideOption/v2.0` — fix dangling `$ref`
- `pricingModel` referenced `PricingModel/v2.0`, which was never authored (dead link). Repointed to the existing **`SystemPricingPlan/v2.0`** across schema.json / attributes.yaml / vocab.jsonld / README.

### 3. Remove duplicated Contract-attribute block from mobility schemas
A "contract-like" block had been copy-pasted into several schemas (with descriptions literally reading "…of the contract"). Removed:
- `items`(→ContractItem), `fulfillments`(→Fulfillment), `state`(→State) from **Itinerary, Journey, Trip, TripUpdate**
- `state`(→State) from **Leg, VehicleJourney**
- `fulfillments`(→Fulfillment) from **Operator, Authority**
- Corrected the copied `id`/`descriptor` descriptions on Itinerary/Journey/Trip/TripUpdate.

## Validation
- All edited/new `schema.json`/`context.jsonld`/`vocab.jsonld` parse; all `attributes.yaml` parse.
- Full `$ref`-graph sanity check across the mobility schema closure: **no broken links**.
- The mobility ride-hailing example JSONs (separate repo) validate against the beckn v2.0.0 API spec and now reference `PriceSpecification/2.2` + `PriceComponent/2.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)